### PR TITLE
Add User Properties to CONNECT packet for MQTT 3.1.1

### DIFF
--- a/Chat-Example/Chat-Example/Services/AuthService.swift
+++ b/Chat-Example/Chat-Example/Services/AuthService.swift
@@ -20,7 +20,8 @@ import CourierCore
             clientId: clientId,
             username: username,
             password: "",
-            isCleanSession: false
+            isCleanSession: false,
+            userProperties: ["service": "hivemq", "type": "public"]
         )
 
         completion(.success(connectOptions))

--- a/Chat-Example/Chat-Example/ViewModels/CourierObservableObject.swift
+++ b/Chat-Example/Chat-Example/ViewModels/CourierObservableObject.swift
@@ -24,10 +24,8 @@ class CourierObservableObject: ObservableObject {
                     JSONMessageAdapter(),
                     TextMessageAdapter()
                 ],
-                isUsernameModificationEnabled: true,
                 autoReconnectInterval: 1,
                 maxAutoReconnectInterval: 30,
-                disableMQTTReconnectOnAuthFailure: true,
                 connectTimeoutPolicy: ConnectTimeoutPolicy(isEnabled: true),
                 idleActivityTimeoutPolicy: IdleActivityTimeoutPolicy(isEnabled: true),
                 countryCodeProvider: { "ID" },

--- a/CourierCore/Models/ConnectOptions.swift
+++ b/CourierCore/Models/ConnectOptions.swift
@@ -17,6 +17,8 @@ public struct ConnectOptions: Equatable {
     public let isCleanSession: Bool
 
     public let isCache: Bool
+    
+    public let userProperties: [String: String]?
 
     public init(
         host: String,
@@ -26,7 +28,8 @@ public struct ConnectOptions: Equatable {
         username: String,
         password: String,
         isCleanSession: Bool = false,
-        isCache: Bool = false
+        isCache: Bool = false,
+        userProperties: [String: String]? = nil
     ) {
         self.host = host
         self.port = port
@@ -36,5 +39,6 @@ public struct ConnectOptions: Equatable {
         self.password = password
         self.isCleanSession = isCleanSession
         self.isCache = isCache
+        self.userProperties = userProperties
     }
 }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTSession.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTSession.swift
@@ -20,6 +20,7 @@ protocol IMQTTSession: AnyObject {
     var transport: MQTTTransportProtocol! { get set }
     var certificates: [Any]! { get set }
     var voip: Bool { get set }
+    var userProperty: [String: String]! { get set}
 
     var shouldEnableActivityCheckTimeout: Bool { get set }
     var shouldEnableConnectCheckTimeout: Bool { get set }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -93,6 +93,7 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
             securityPolicy: securityPolicy,
             certificates: nil,
             protocolLevel: .version311,
+            userProperties: connectOptions.userProperties,
             connectHandler: nil
         )
     }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -37,6 +37,7 @@ protocol IMQTTClientFrameworkSessionManager {
         securityPolicy: MQTTSSLSecurityPolicy?,
         certificates: [Any]?,
         protocolLevel: MQTTProtocolVersion,
+        userProperties: [String: String]?,
         connectHandler: MQTTConnectHandler?)
 
     func disconnect(with disconnectHandler: MQTTDisconnectHandler?)
@@ -144,6 +145,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         securityPolicy: MQTTSSLSecurityPolicy? = nil,
         certificates: [Any]? = nil,
         protocolLevel: MQTTProtocolVersion = .version311,
+        userProperties: [String: String]? = nil,
         connectHandler: MQTTConnectHandler? = nil) {
         printDebug("MQTT - COURIER: Client Session Manager connect to: \(host)")
         let shouldReconnect = self.session != nil
@@ -214,6 +216,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
             session?.persistence = persistence
 
             session?.delegate = self
+            session?.userProperty = userProperties
             self.reconnectFlag = false
         }
 

--- a/CourierTests/Core/Mocks/MockMQTTClientFrameworkSessionManager.swift
+++ b/CourierTests/Core/Mocks/MockMQTTClientFrameworkSessionManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import MQTTClientGJ
 @testable import CourierCore
 @testable import CourierMQTT
+
 class MockMQTTClientFrameworkSessionManager: IMQTTClientFrameworkSessionManager {
 
     var invokedSessionGetter = false
@@ -36,8 +37,8 @@ class MockMQTTClientFrameworkSessionManager: IMQTTClientFrameworkSessionManager 
 
     var invokedConnect = false
     var invokedConnectCount = 0
-    var invokedConnectParameters: (host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, connectHandler: MQTTConnectHandler?)?
-    var invokedConnectParametersList = [(host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, connectHandler: MQTTConnectHandler?)]()
+    var invokedConnectParameters: (host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, connectHandler: MQTTConnectHandler?)?
+    var invokedConnectParametersList = [(host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, connectHandler: MQTTConnectHandler?)]()
 
     func connect(
         to host: String,
@@ -56,11 +57,12 @@ class MockMQTTClientFrameworkSessionManager: IMQTTClientFrameworkSessionManager 
         securityPolicy: MQTTSSLSecurityPolicy?,
         certificates: [Any]?,
         protocolLevel: MQTTProtocolVersion,
+        userProperties: [String: String]?,
         connectHandler: MQTTConnectHandler?) {
         invokedConnect = true
         invokedConnectCount += 1
-        invokedConnectParameters = (host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, connectHandler)
-        invokedConnectParametersList.append((host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, connectHandler))
+        invokedConnectParameters = (host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, connectHandler)
+        invokedConnectParametersList.append((host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, connectHandler))
     }
 
     var invokedDisconnect = false

--- a/CourierTests/Core/Mocks/MockMQTTSession.swift
+++ b/CourierTests/Core/Mocks/MockMQTTSession.swift
@@ -401,6 +401,28 @@ class MockMQTTSession: IMQTTSession {
         }
     }
 
+    var invokedUserPropertySetter = false
+    var invokedUserPropertySetterCount = 0
+    var invokedUserProperty: [String: String]?
+    var invokedUserPropertyList = [[String: String]?]()
+    var invokedUserPropertyGetter = false
+    var invokedUserPropertyGetterCount = 0
+    var stubbedUserProperty: [String: String]!
+
+    var userProperty: [String: String]! {
+        set {
+            invokedUserPropertySetter = true
+            invokedUserPropertySetterCount += 1
+            invokedUserProperty = newValue
+            invokedUserPropertyList.append(newValue)
+        }
+        get {
+            invokedUserPropertyGetter = true
+            invokedUserPropertyGetterCount += 1
+            return stubbedUserProperty
+        }
+    }
+
     var invokedShouldEnableActivityCheckTimeoutSetter = false
     var invokedShouldEnableActivityCheckTimeoutSetterCount = 0
     var invokedShouldEnableActivityCheckTimeout: Bool?

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
@@ -151,7 +151,6 @@
     if (protocolLevel == MQTTProtocolVersion311) {
         NSMutableData *properties = [[NSMutableData alloc] init];
         [self updateProperties:properties userProperty:userProperty];
-        [data appendVariableLength:properties.length];
         [data appendData:properties];
     }
     

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
@@ -136,6 +136,17 @@
         }
         [data appendVariableLength:properties.length];
         [data appendData:properties];
+    } else if (protocolLevel == MQTTProtocolVersion311) {
+        NSMutableData *properties = [[NSMutableData alloc] init];
+        if (userProperty) {
+            for (NSString *key in userProperty.allKeys) {
+                [properties appendByte:MQTTUserProperty];
+                [properties appendMQTTString:key];
+                [properties appendMQTTString:userProperty[key]];
+            }
+        }
+        [data appendVariableLength:properties.length];
+        [data appendData:properties];
     }
 
     [data appendMQTTString:clientId];


### PR DESCRIPTION
MQTTClientFramework had already passing userProperties dictionary for MQTT Protocol 5
For this MR, i added several implementations:
- Accept userProperties optional dictionary in ConnectOptions initializer, this can be user by the public to provide their properties.
- Update MQTTMessage.m in MQTTCF to also inject userProperties 0x26/38 for MQTT Protocol 3.1.1.