### PR TITLE
Fix - nil is not a legal NSPersistentStoreCoordinator for searching for entity name

### DIFF
--- a/CourierMQTT/MQTT/Client/Factory/IMQTTClientFactory.swift
+++ b/CourierMQTT/MQTT/Client/Factory/IMQTTClientFactory.swift
@@ -7,10 +7,8 @@ protocol IMQTTClientFactory {
 
 struct MQTTClientFactory: IMQTTClientFactory {
 
-    let isPersistenceEnabled: Bool
-
     func makeClient(configuration: IMQTTConfiguration, reachability: Reachability?, dispatchQueue: DispatchQueue) -> IMQTTClient {
-        let factory = MQTTClientFrameworkConnectionFactory(clientFactory: MQTTClientFrameworkFactory(isPersistenceEnabled: isPersistenceEnabled))
+        let factory = MQTTClientFrameworkConnectionFactory(clientFactory: MQTTClientFrameworkFactory())
         return MQTTClient(configuration: configuration, mqttConnectionFactory: factory, reachability: reachability, dispatchQueue: dispatchQueue)
     }
 }

--- a/CourierMQTT/MQTT/Client/MQTTClient.swift
+++ b/CourierMQTT/MQTT/Client/MQTTClient.swift
@@ -53,7 +53,9 @@ class MQTTClient: IMQTTClient {
             eventHandler: configuration.eventHandler,
             authFailureHandler: configuration.authFailureHandler,
             connectTimeoutPolicy: configuration.connectTimeoutPolicy,
-            idleActivityTimeoutPolicy: configuration.idleActivityTimeoutPolicy
+            idleActivityTimeoutPolicy: configuration.idleActivityTimeoutPolicy,
+            isPersistent: configuration.isMQTTPersistentEnabled,
+            shouldInitializeCoreDataPersistenceContext: configuration.shouldInitializeCoreDataPersistenceContext
         )
 
         connection = mqttConnectionFactory.makeConnection(connectionConfig: connectionConfig)

--- a/CourierMQTT/MQTT/Configuration/IMQTTConfiguration.swift
+++ b/CourierMQTT/MQTT/Configuration/IMQTTConfiguration.swift
@@ -7,6 +7,10 @@ protocol IMQTTConfiguration {
     var idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol { get }
     var authFailureHandler: IAuthFailureHandler { get }
     var eventHandler: ICourierEventHandler { get }
+    
     var messagePersistenceTTLSeconds: TimeInterval { get }
     var messageCleanupInterval: TimeInterval { get }
+    
+    var isMQTTPersistentEnabled: Bool { get }
+    var shouldInitializeCoreDataPersistenceContext: Bool { get }
 }

--- a/CourierMQTT/MQTT/Configuration/MQTTConfiguration.swift
+++ b/CourierMQTT/MQTT/Configuration/MQTTConfiguration.swift
@@ -9,6 +9,8 @@ struct MQTTConfiguration: IMQTTConfiguration {
     var eventHandler: ICourierEventHandler
     var messagePersistenceTTLSeconds: TimeInterval
     var messageCleanupInterval: TimeInterval
+    var isMQTTPersistentEnabled: Bool
+    var shouldInitializeCoreDataPersistenceContext: Bool
 
     init(connectRetryTimePolicy: IConnectRetryTimePolicy = ConnectRetryTimePolicy(),
          connectTimeoutPolicy: IConnectTimeoutPolicy = ConnectTimeoutPolicy(),
@@ -16,7 +18,9 @@ struct MQTTConfiguration: IMQTTConfiguration {
          authFailureHandler: IAuthFailureHandler,
          eventHandler: ICourierEventHandler,
          messagePersistenceTTLSeconds: TimeInterval = 0,
-         messageCleanupInterval: TimeInterval = 10) {
+         messageCleanupInterval: TimeInterval = 10,
+         isMQTTPersistentEnabled: Bool,
+         shouldInitializeCoreDataPersistenceContext: Bool) {
         self.connectRetryTimePolicy = connectRetryTimePolicy
         self.connectTimeoutPolicy = connectTimeoutPolicy
         self.idleActivityTimeoutPolicy = idleActivityTimeoutPolicy
@@ -24,5 +28,7 @@ struct MQTTConfiguration: IMQTTConfiguration {
         self.eventHandler = eventHandler
         self.messagePersistenceTTLSeconds = messagePersistenceTTLSeconds
         self.messageCleanupInterval = messageCleanupInterval
+        self.isMQTTPersistentEnabled = isMQTTPersistentEnabled
+        self.shouldInitializeCoreDataPersistenceContext = shouldInitializeCoreDataPersistenceContext
     }
 }

--- a/CourierMQTT/MQTT/Connection/Factory/IMQTTConnectionFactory.swift
+++ b/CourierMQTT/MQTT/Connection/Factory/IMQTTConnectionFactory.swift
@@ -10,7 +10,11 @@ struct MQTTClientFrameworkConnectionFactory: IMQTTConnectionFactory {
     let clientFactory: IMQTTClientFrameworkFactory
 
     func makeConnection(connectionConfig: ConnectionConfig) -> IMQTTConnection {
-        MQTTClientFrameworkConnection(connectionConfig: connectionConfig, clientFactory: clientFactory)
+        MQTTClientFrameworkConnection(connectionConfig: connectionConfig,
+                                      clientFactory: clientFactory,
+                                      persistenceFactory: MQTTPersistenceFactory(
+                                        isPersistent: connectionConfig.isPersistent,
+                                        shouldInitializeCoreDataPersistenceContext: connectionConfig.shouldInitializeCoreDataPersistenceContext))
     }
 
 }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTClientFrameworkFactory.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTClientFrameworkFactory.swift
@@ -14,14 +14,11 @@ protocol IMQTTClientFrameworkFactory {
 
 struct MQTTClientFrameworkFactory: IMQTTClientFrameworkFactory {
 
-    let isPersistenceEnabled: Bool
-
     func makeSessionManager(connectRetryTimePolicy: IConnectRetryTimePolicy, persistenceFactory: IMQTTPersistenceFactory, dispatchQueue: DispatchQueue, delegate: MQTTClientFrameworkSessionManagerDelegate, connectTimeoutPolicy: IConnectTimeoutPolicy,
                             idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol) -> IMQTTClientFrameworkSessionManager {
         guard !MQTTClientcourier.isEmpty else { fatalError("Please use the MQTTClientGJ from courier podspecs") }
 
         let sessionManager = MQTTClientFrameworkSessionManager(
-            persistence: isPersistenceEnabled,
             retryInterval: TimeInterval(connectRetryTimePolicy.autoReconnectInterval),
             maxRetryInterval: TimeInterval(connectRetryTimePolicy.maxAutoReconnectInterval),
             streamSSLLevel: kCFStreamSocketSecurityLevelNegotiatedSSL as String,

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTPersistence.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTPersistence.swift
@@ -1,13 +1,34 @@
 import Foundation
 import MQTTClientGJ
 
-protocol IMQTTPersistenceFactory {
+protocol IMQTTPersistenceFactory {    
     func makePersistence() -> MQTTPersistence
 }
 
 struct MQTTPersistenceFactory: IMQTTPersistenceFactory {
 
+    let isPersistent: Bool
+    let shouldInitializeCoreDataPersistenceContext: Bool
+
+    private let maxWindowSize: Int = 16
+    private let maxMessages: Int = 5000
+    private let maxSize: Int = 128 * 1024 * 1024
+    
+    init(isPersistent: Bool = false, shouldInitializeCoreDataPersistenceContext: Bool = true) {
+        self.isPersistent = isPersistent
+        self.shouldInitializeCoreDataPersistenceContext = shouldInitializeCoreDataPersistenceContext
+    }
+    
     func makePersistence() -> MQTTPersistence {
-        MQTTCoreDataPersistence()
+        let persistence = MQTTCoreDataPersistence()
+        persistence.persistent = isPersistent
+        persistence.maxWindowSize = UInt(self.maxWindowSize)
+        persistence.maxSize = UInt(self.maxSize)
+        persistence.maxMessages = UInt(self.maxMessages)
+        
+        if shouldInitializeCoreDataPersistenceContext {
+            persistence.initializeManagedObjectContext()
+        }
+        return persistence
     }
 }

--- a/CourierMQTT/MQTT/CourierClientFactory.swift
+++ b/CourierMQTT/MQTT/CourierClientFactory.swift
@@ -42,6 +42,8 @@ public struct MQTTClientConfig {
     
     public let messageCleanupInterval: TimeInterval
     
+    public let shouldInitializeCoreDataPersistenceContext: Bool
+    
     public var incomingMessagePersistenceEnabled: Bool {
         messagePersistenceTTLSeconds > 0
     }
@@ -58,7 +60,8 @@ public struct MQTTClientConfig {
         connectTimeoutPolicy: IConnectTimeoutPolicy = ConnectTimeoutPolicy(),
         idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol = IdleActivityTimeoutPolicy(),
         messagePersistenceTTLSeconds: TimeInterval = 0,
-        messageCleanupInterval: TimeInterval = 10
+        messageCleanupInterval: TimeInterval = 10,
+        shouldInitializeCoreDataPersistenceContext: Bool = true
     ) {
         self.topics = topics
         self.authService = authService
@@ -72,6 +75,7 @@ public struct MQTTClientConfig {
         self.idleActivityTimeoutPolicy = idleActivityTimeoutPolicy
         self.messagePersistenceTTLSeconds = messagePersistenceTTLSeconds
         self.messageCleanupInterval = messageCleanupInterval
+        self.shouldInitializeCoreDataPersistenceContext = shouldInitializeCoreDataPersistenceContext
     }
 
 }

--- a/CourierMQTT/MQTT/MQTTCourierClient.swift
+++ b/CourierMQTT/MQTT/MQTTCourierClient.swift
@@ -57,14 +57,14 @@ class MQTTCourierClient: CourierClient {
     convenience init(config: MQTTClientConfig) {
         self.init(
             config: config,
-            mqttClientFactory: MQTTClientFactory(isPersistenceEnabled: config.isMessagePersistenceEnabled)
+            mqttClientFactory: MQTTClientFactory()
         )
     }
 
     init(config: MQTTClientConfig,
          subscriptionStoreFactory: ISubscriptionStoreFactory = SubscriptionStoreFactory(),
          multicastEventHandlerFactory: IMulticastCourierEventHandlerFactory = MulticastCourierEventHandlerFactory(),
-         mqttClientFactory: IMQTTClientFactory = MQTTClientFactory(isPersistenceEnabled: false),
+         mqttClientFactory: IMQTTClientFactory = MQTTClientFactory(),
          authRetryPolicy: IAuthRetryPolicy = AuthRetryPolicy()) {
 
         self.config = config
@@ -85,7 +85,9 @@ class MQTTCourierClient: CourierClient {
             authFailureHandler: self,
             eventHandler: courierEventHandler,
             messagePersistenceTTLSeconds: config.messagePersistenceTTLSeconds,
-            messageCleanupInterval: config.messageCleanupInterval)
+            messageCleanupInterval: config.messageCleanupInterval,
+            isMQTTPersistentEnabled: config.isMessagePersistenceEnabled,
+            shouldInitializeCoreDataPersistenceContext: config.shouldInitializeCoreDataPersistenceContext)
 
         let reachability = try? Reachability()
         self.client = mqttClientFactory.makeClient(configuration: configuration, reachability: reachability, dispatchQueue: dispatchQueue)

--- a/CourierMQTT/MQTT/Models/ConnectionConfig.swift
+++ b/CourierMQTT/MQTT/Models/ConnectionConfig.swift
@@ -7,4 +7,7 @@ struct ConnectionConfig {
     var authFailureHandler: IAuthFailureHandler
     var connectTimeoutPolicy: IConnectTimeoutPolicy
     var idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol
+    
+    var isPersistent: Bool
+    var shouldInitializeCoreDataPersistenceContext: Bool
 }

--- a/CourierMQTT/Utils/PrintDebug.swift
+++ b/CourierMQTT/Utils/PrintDebug.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func printDebug(_ text: String) {
-    #if ALPHA || DEBUG || INTEGRATION
+//    #if ALPHA || DEBUG || INTEGRATION
     NSLog(text, [])
-    #endif
+//    #endif
 }

--- a/CourierMQTT/Utils/PrintDebug.swift
+++ b/CourierMQTT/Utils/PrintDebug.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func printDebug(_ text: String) {
-//    #if ALPHA || DEBUG || INTEGRATION
+    #if ALPHA || DEBUG || INTEGRATION
     NSLog(text, [])
-//    #endif
+    #endif
 }

--- a/CourierTests/Core/MQTT/Client/MQTTClientTests.swift
+++ b/CourierTests/Core/MQTT/Client/MQTTClientTests.swift
@@ -292,7 +292,7 @@ extension MQTTClientTests {
 
     var stubbedConfiguration: IMQTTConfiguration {
         MQTTConfiguration(
-            connectRetryTimePolicy: mockConnectRetryTimePolicy, authFailureHandler: mockAuthFailureHandler, eventHandler: mockEventHandler)
+            connectRetryTimePolicy: mockConnectRetryTimePolicy, authFailureHandler: mockAuthFailureHandler, eventHandler: mockEventHandler, isMQTTPersistentEnabled: true, shouldInitializeCoreDataPersistenceContext: true)
     }
 
     var stubConnectOptions: ConnectOptions {

--- a/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
+++ b/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
@@ -39,7 +39,9 @@ class MQTTClientFrameworkConnectionTests: XCTestCase {
                 eventHandler: mockEventHandler,
                 authFailureHandler: mockAuthFailureHandler,
                 connectTimeoutPolicy: mockConnectTimeoutPolicy,
-                idleActivityTimeoutPolicy: IdleActivityTimeoutPolicy()
+                idleActivityTimeoutPolicy: IdleActivityTimeoutPolicy(),
+                isPersistent: true,
+                shouldInitializeCoreDataPersistenceContext: true
             ),
             clientFactory: mockClientFactory,
             persistenceFactory: mockPersistenceFactory

--- a/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkSessionManagerTests.swift
+++ b/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkSessionManagerTests.swift
@@ -22,10 +22,6 @@ class MQTTClientFrameworkSessionManagerTests: XCTestCase {
         mockDelegate = MockMQTTClientFrameworkSessionManagerDelegate()
 
         sut = MQTTClientFrameworkSessionManager(
-            persistence: true,
-            maxWindowSize: 100,
-            maxMessages: 100,
-            maxSize: 100,
             retryInterval: 10,
             maxRetryInterval: 15,
             streamSSLLevel: "9999",
@@ -62,11 +58,6 @@ class MQTTClientFrameworkSessionManagerTests: XCTestCase {
         XCTAssertEqual(mockSession.invokedQueue, .main)
         XCTAssertNil(mockSession.invokedCertificates)
         XCTAssertEqual(mockSession.invokedStreamSSLLevel, "9999")
-        XCTAssertTrue(mockSession.invokedPersistence === mockPersistence)
-        XCTAssertTrue(mockPersistence.invokedPersistent!)
-        XCTAssertEqual(mockPersistence.invokedMaxWindowSize, UInt(100))
-        XCTAssertEqual(mockPersistence.invokedMaxSize, UInt(100))
-        XCTAssertEqual(mockPersistence.invokedMaxMessages, UInt(100))
         XCTAssertTrue(mockSession.invokedDelegate === sut)
         XCTAssertFalse(mockSession.invokedClose)
         XCTAssertEqual(sut.state, .connecting)

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.h
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.h
@@ -8,7 +8,7 @@
 #import "MQTTPersistence.h"
 
 @interface MQTTCoreDataPersistence : NSObject <MQTTPersistence>
-
+- (void)initializeManagedObjectContext;
 @end
 
 @interface MQTTFlow : NSManagedObject <MQTTFlow>

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.m
@@ -479,8 +479,10 @@
                                                         options:options
                                                           error:&error]) {
         DDLogError(@"[MQTTPersistence] managedObjectContext save: %@", error);
-        [[NSNotificationCenter defaultCenter]
-         postNotificationName:@"MQTTPersistenceFailedToAddStore" object:nil userInfo: @{NSLocalizedDescriptionKey: error.localizedDescription}];
+        if (error) {
+            [[NSNotificationCenter defaultCenter]
+             postNotificationName:@"MQTTPersistenceFailedToAddStore" object:nil userInfo: @{NSLocalizedDescriptionKey: error.localizedDescription}];
+        }
         persistentStoreCoordinator = nil;
     }
     
@@ -495,8 +497,10 @@
                                                             options:options
                                                               error:&error]) {
             DDLogError(@"[MQTTPersistence] managedObjectContext save: %@", error);
-            [[NSNotificationCenter defaultCenter]
-             postNotificationName:@"MQTTPersistenceFailedToAddStore" object:nil userInfo: @{NSLocalizedDescriptionKey: error.localizedDescription}];
+            if (error) {
+                [[NSNotificationCenter defaultCenter]
+                 postNotificationName:@"MQTTPersistenceFailedToAddStore" object:nil userInfo: @{NSLocalizedDescriptionKey: error.localizedDescription}];
+            }
             persistentStoreCoordinator = nil;
         }
     }

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.m
@@ -192,6 +192,10 @@
     return self;
 }
 
+- (void)initializeManagedObjectContext {
+    [self managedObjectContext];
+}
+
 - (NSManagedObjectContext *)managedObjectContext {
     if (!_managedObjectContext) {
         NSPersistentStoreCoordinator *coordinator = [self createPersistentStoreCoordinator];

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.m
@@ -479,12 +479,12 @@
                                                         options:options
                                                           error:&error]) {
         DDLogError(@"[MQTTPersistence] managedObjectContext save: %@", error);
+        [[NSNotificationCenter defaultCenter]
+         postNotificationName:@"MQTTPersistenceFailedToAddStore" object:nil userInfo: @{NSLocalizedDescriptionKey: error.localizedDescription}];
         persistentStoreCoordinator = nil;
     }
-
-      
-      
-     if (persistentStoreCoordinator == nil && error != nil && self.persistent) {
+    
+    if (persistentStoreCoordinator == nil && error != nil && self.persistent) {
         DDLogError(@"[MQTTPersistence] Initializing Persistent Store with SQLite failed, will try to use inMemory instead to avoid crashes");
         persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc]
                                       initWithManagedObjectModel:model];
@@ -495,6 +495,8 @@
                                                             options:options
                                                               error:&error]) {
             DDLogError(@"[MQTTPersistence] managedObjectContext save: %@", error);
+            [[NSNotificationCenter defaultCenter]
+             postNotificationName:@"MQTTPersistenceFailedToAddStore" object:nil userInfo: @{NSLocalizedDescriptionKey: error.localizedDescription}];
             persistentStoreCoordinator = nil;
         }
     }


### PR DESCRIPTION
This MR fixes the issue for a rare crash "nil is not a legal NSPersistentStoreCoordinator for searching for entity name" by making MQTTPersistent utilize a single instance instead of recreating when connection options changes.

It also provides flag to initialize the ManagedObjectContext immediately at the time of Courier Initialization to avoid any future race condition issue