### PR TITLE
Add Batch Delete on MQTTFlow

### DIFF
--- a/CourierMQTT/MQTT/Client/IMQTTClient.swift
+++ b/CourierMQTT/MQTT/Client/IMQTTClient.swift
@@ -18,7 +18,7 @@ protocol IMQTTClient {
     func unsubscribe(_ topics: [String])
 
     func send(packet: MQTTPacket)
-    func deleteAllPersistedMessages(clientId: String)
+    func deleteAllPersistedMessages()
 
     func reset()
     func destroy()

--- a/CourierMQTT/MQTT/Client/MQTTClient.swift
+++ b/CourierMQTT/MQTT/Client/MQTTClient.swift
@@ -91,8 +91,8 @@ class MQTTClient: IMQTTClient {
         connection.publish(packet: packet)
     }
 
-    func deleteAllPersistedMessages(clientId: String) {
-        connection.deleteAllPersistedMessages(clientId: clientId)
+    func deleteAllPersistedMessages() {
+        connection.deleteAllPersistedMessages()
     }
 
     func subscribe(_ topics: [(topic: String, qos: QoS)]) {

--- a/CourierMQTT/MQTT/Connection/IMQTTConnection.swift
+++ b/CourierMQTT/MQTT/Connection/IMQTTConnection.swift
@@ -12,7 +12,7 @@ protocol IMQTTConnection {
     func disconnect()
 
     func publish(packet: MQTTPacket)
-    func deleteAllPersistedMessages(clientId: String)
+    func deleteAllPersistedMessages()
 
     func subscribe(_ topics: [(topic: String, qos: QoS)])
     func unsubscribe(_ topics: [String])

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -113,12 +113,8 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
         sessionManager.publish(packet: packet)
     }
 
-    func deleteAllPersistedMessages(clientId: String) {
-        let persistence = persistenceFactory.makePersistence()
-        persistence.persistent = true
-        mqttDispatchQueue.async {
-            persistence.deleteAllFlows(forClientId: clientId)
-        }
+    func deleteAllPersistedMessages() {
+        sessionManager.deleteAllPersistedMessages()
     }
 
     func subscribe(_ topics: [(topic: String, qos: QoS)]) {

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -45,6 +45,8 @@ protocol IMQTTClientFrameworkSessionManager {
 
     func subscribe(_ topics: [(topic: String, qos: QoS)])
     func unsubscribe(_ topics: [String])
+    
+    func deleteAllPersistedMessages()
 }
 
 class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionManager {
@@ -310,6 +312,19 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
 
     func publish(packet: MQTTPacket) {
         sendData(packet.data, topic: packet.topic, qos: MQTTQosLevel(qos: packet.qos), retainFlag: false)
+    }
+    
+    func deleteAllPersistedMessages() {
+        let _persistence: MQTTCoreDataPersistence
+        if self.persistence.persistent, let coreDataPeristence = self.persistence as? MQTTCoreDataPersistence {
+            _persistence = coreDataPeristence
+        } else {
+            _persistence = MQTTCoreDataPersistence()
+            _persistence.persistent = true
+        }
+        queue.async {
+            _persistence.deleteAllFlows()
+        }
     }
 }
 

--- a/CourierMQTT/MQTT/MQTTCourierClient.swift
+++ b/CourierMQTT/MQTT/MQTTCourierClient.swift
@@ -286,7 +286,7 @@ class MQTTCourierClient: CourierClient {
     func destroy() {
         isDestroyed  = true
         subscriptionStore.clearAllSubscriptions()
-        client.deleteAllPersistedMessages(clientId: client.connectOptions?.clientId ?? connectionServiceProvider.clientId)
+        client.deleteAllPersistedMessages()
         client.messageReceiverListener.clearPersistedMessages()
         disconnect()
     }

--- a/CourierTests/Core/MQTT/Client/MQTTClientTests.swift
+++ b/CourierTests/Core/MQTT/Client/MQTTClientTests.swift
@@ -282,7 +282,7 @@ class MQTTClientTests: XCTestCase {
     }
 
     func testDeleteAllPersistedMessages() {
-        sut.deleteAllPersistedMessages(clientId: "xyz")
+        sut.deleteAllPersistedMessages()
         XCTAssertTrue(mockConnection.invokedDeleteAllPersistedMessages)
     }
 

--- a/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
+++ b/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
@@ -436,17 +436,14 @@ class MQTTClientFrameworkConnectionTests: XCTestCase {
     }
     
     func testDeleteAllPersistedMessage() {
-        sut.deleteAllPersistedMessages(clientId: "xxx")
-        XCTAssertTrue(mockPersistence.invokedPersistentSetter)
-        XCTAssertTrue(mockPersistence.invokedPersistent!)
-        
+        sut.deleteAllPersistedMessages()
+    
         let expectation_ = expectation(description: "test")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
             expectation_.fulfill()
         }
         waitForExpectations(timeout: 0.1) { _ in
-            XCTAssertTrue(self.mockPersistence.invokedDeleteAllFlows)
-            XCTAssertEqual(self.mockPersistence.invokedDeleteAllFlowsParameters?.clientId, "xxx")
+            XCTAssertTrue(self.mockSessionManager.invokedDeleteAllPersistedMessages)
         }
     }
 }

--- a/CourierTests/Core/Mocks/MockMQTTClient.swift
+++ b/CourierTests/Core/Mocks/MockMQTTClient.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import CourierCore
 @testable import CourierMQTT
+
 class MockMQTTClient: IMQTTClient {
 
     var invokedIsConnectedGetter = false
@@ -52,7 +53,7 @@ class MockMQTTClient: IMQTTClient {
         invokedSubscribedMessageStreamGetterCount += 1
         return stubbedSubscribedMessageStream
     }
-    
+
     var invokedMessageReceiverListenerGetter = false
     var invokedMessageReceiverListenerGetterCount = 0
     var stubbedMessageReceiverListener: IMessageReceiveListener!
@@ -129,14 +130,10 @@ class MockMQTTClient: IMQTTClient {
 
     var invokedDeleteAllPersistedMessages = false
     var invokedDeleteAllPersistedMessagesCount = 0
-    var invokedDeleteAllPersistedMessagesParameters: (clientId: String, Void)?
-    var invokedDeleteAllPersistedMessagesParametersList = [(clientId: String, Void)]()
 
-    func deleteAllPersistedMessages(clientId: String) {
+    func deleteAllPersistedMessages() {
         invokedDeleteAllPersistedMessages = true
         invokedDeleteAllPersistedMessagesCount += 1
-        invokedDeleteAllPersistedMessagesParameters = (clientId, ())
-        invokedDeleteAllPersistedMessagesParametersList.append((clientId, ()))
     }
 
     var invokedReset = false

--- a/CourierTests/Core/Mocks/MockMQTTClientFrameworkSessionManager.swift
+++ b/CourierTests/Core/Mocks/MockMQTTClientFrameworkSessionManager.swift
@@ -112,4 +112,12 @@ class MockMQTTClientFrameworkSessionManager: IMQTTClientFrameworkSessionManager 
         invokedUnsubscribeParameters = (topics, ())
         invokedUnsubscribeParametersList.append((topics, ()))
     }
+
+    var invokedDeleteAllPersistedMessages = false
+    var invokedDeleteAllPersistedMessagesCount = 0
+
+    func deleteAllPersistedMessages() {
+        invokedDeleteAllPersistedMessages = true
+        invokedDeleteAllPersistedMessagesCount += 1
+    }
 }

--- a/CourierTests/Core/Mocks/MockMQTTConnection.swift
+++ b/CourierTests/Core/Mocks/MockMQTTConnection.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import CourierCore
 @testable import CourierMQTT
+
 class MockMQTTConnection: IMQTTConnection {
 
     var invokedIsConnectedGetter = false
@@ -87,14 +88,10 @@ class MockMQTTConnection: IMQTTConnection {
 
     var invokedDeleteAllPersistedMessages = false
     var invokedDeleteAllPersistedMessagesCount = 0
-    var invokedDeleteAllPersistedMessagesParameters: (clientId: String, Void)?
-    var invokedDeleteAllPersistedMessagesParametersList = [(clientId: String, Void)]()
 
-    func deleteAllPersistedMessages(clientId: String) {
+    func deleteAllPersistedMessages() {
         invokedDeleteAllPersistedMessages = true
         invokedDeleteAllPersistedMessagesCount += 1
-        invokedDeleteAllPersistedMessagesParameters = (clientId, ())
-        invokedDeleteAllPersistedMessagesParametersList.append((clientId, ()))
     }
 
     var invokedSubscribe = false

--- a/CourierTests/Core/Mocks/MockMQTTPersistence.swift
+++ b/CourierTests/Core/Mocks/MockMQTTPersistence.swift
@@ -2,7 +2,7 @@ import Foundation
 import MQTTClientGJ
 @testable import CourierCore
 @testable import CourierMQTT
-class MockMQTTPersistence: MQTTPersistence {
+class MockMQTTPersistence: MQTTCoreDataPersistence {
 
     var invokedMaxWindowSizeSetter = false
     var invokedMaxWindowSizeSetterCount = 0
@@ -11,7 +11,7 @@ class MockMQTTPersistence: MQTTPersistence {
     var invokedMaxWindowSizeGetter = false
     var invokedMaxWindowSizeGetterCount = 0
     var stubbedMaxWindowSize: UInt!
-    var maxWindowSize: UInt {
+    override var maxWindowSize: UInt {
         set {
             invokedMaxWindowSizeSetter = true
             invokedMaxWindowSizeSetterCount += 1
@@ -34,7 +34,7 @@ class MockMQTTPersistence: MQTTPersistence {
     var invokedMaxMessagesGetterCount = 0
     var stubbedMaxMessages: UInt!
 
-    var maxMessages: UInt {
+    override var maxMessages: UInt {
         set {
             invokedMaxMessagesSetter = true
             invokedMaxMessagesSetterCount += 1
@@ -56,7 +56,7 @@ class MockMQTTPersistence: MQTTPersistence {
     var invokedPersistentGetter = false
     var invokedPersistentGetterCount = 0
     var stubbedPersistent: Bool!
-    var persistent: Bool {
+    override var persistent: Bool {
         set {
             invokedPersistentSetter = true
             invokedPersistentSetterCount += 1
@@ -78,7 +78,7 @@ class MockMQTTPersistence: MQTTPersistence {
     var invokedMaxSizeGetter = false
     var invokedMaxSizeGetterCount = 0
     var stubbedMaxSize: UInt!
-    var maxSize: UInt {
+    override var maxSize: UInt {
         set {
             invokedMaxSizeSetter = true
             invokedMaxSizeSetterCount += 1
@@ -93,35 +93,35 @@ class MockMQTTPersistence: MQTTPersistence {
         }
     }
 
-    func windowSize(_ clientId: String!) -> UInt {
+    override func windowSize(_ clientId: String!) -> UInt {
         0
     }
 
-    func storeMessage(forClientId clientId: String!, topic: String!, data: Data!, retainFlag: Bool, qos: MQTTQosLevel, msgId: UInt16, incomingFlag: Bool, commandType: UInt8, deadline: Date!) -> MQTTFlowProtocol! {
+    override func storeMessage(forClientId clientId: String!, topic: String!, data: Data!, retainFlag: Bool, qos: MQTTQosLevel, msgId: UInt16, incomingFlag: Bool, commandType: UInt8, deadline: Date!) -> MQTTFlowProtocol! {
         nil
     }
 
-    func delete(_ flow: MQTTFlowProtocol!) {}
+    override func delete(_ flow: MQTTFlowProtocol!) {}
 
     var invokedDeleteAllFlows = false
     var invokedDeleteAllFlowsCount = 0
     var invokedDeleteAllFlowsParameters: (clientId: String, Void)?
     var invokedDeleteAllFlowsParametersList = [(clientId: String, Void)]()
-    func deleteAllFlows(forClientId clientId: String!) {
+    override func deleteAllFlows(forClientId clientId: String!) {
         invokedDeleteAllFlows = true
         invokedDeleteAllFlowsCount += 1
         invokedDeleteAllFlowsParameters = (clientId, ())
         invokedDeleteAllFlowsParametersList.append((clientId, ()))
     }
 
-    func allFlowsforClientId(_ clientId: String!, incomingFlag: Bool) -> [Any]! {
+    override func allFlowsforClientId(_ clientId: String!, incomingFlag: Bool) -> [Any]! {
         nil
     }
 
-    func flowforClientId(_ clientId: String!, incomingFlag: Bool, messageId: UInt16) -> MQTTFlowProtocol! {
+    override func flowforClientId(_ clientId: String!, incomingFlag: Bool, messageId: UInt16) -> MQTTFlowProtocol! {
         nil
     }
 
-    func sync() {}
+    override func sync() {}
 
 }

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.h
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.h
@@ -9,6 +9,7 @@
 
 @interface MQTTCoreDataPersistence : NSObject <MQTTPersistence>
 - (void)initializeManagedObjectContext;
+- (void)deleteAllFlows;
 @end
 
 @interface MQTTFlow : NSManagedObject <MQTTFlow>


### PR DESCRIPTION
- Use existing persistence store instead of creating new one when persistent flag is true
- Update method to batch delete all MQTTFlowMessages instead of specific clientID