### PR TITLE
Add ALPN Support

### DIFF
--- a/CourierCore/Models/ConnectOptions.swift
+++ b/CourierCore/Models/ConnectOptions.swift
@@ -17,6 +17,8 @@ public struct ConnectOptions: Equatable {
     public let isCleanSession: Bool
     
     public let userProperties: [String: String]?
+    
+    public let alpn: [String]?
 
     public init(
         host: String,
@@ -26,7 +28,8 @@ public struct ConnectOptions: Equatable {
         username: String,
         password: String,
         isCleanSession: Bool = false,
-        userProperties: [String: String]? = nil
+        userProperties: [String: String]? = nil,
+        alpn: [String]? = nil
     ) {
         self.host = host
         self.port = port
@@ -36,5 +39,6 @@ public struct ConnectOptions: Equatable {
         self.password = password
         self.isCleanSession = isCleanSession
         self.userProperties = userProperties
+        self.alpn = alpn
     }
 }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -99,6 +99,7 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
             certificates: nil,
             protocolLevel: .version311,
             userProperties: connectOptions.userProperties,
+            alpn: connectOptions.alpn,
             connectHandler: nil
         )
     }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -38,6 +38,7 @@ protocol IMQTTClientFrameworkSessionManager {
         certificates: [Any]?,
         protocolLevel: MQTTProtocolVersion,
         userProperties: [String: String]?,
+        alpn: [String]?,
         connectHandler: MQTTConnectHandler?)
 
     func disconnect(with disconnectHandler: MQTTDisconnectHandler?)
@@ -84,6 +85,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
     private var securityPolicy: MQTTSSLSecurityPolicy?
     private var certificates: [Any]?
     private var protocolLevel: MQTTProtocolVersion?
+    private var alpn: [String]?
 
     private var streamSSLLevel: String
 
@@ -136,6 +138,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         certificates: [Any]? = nil,
         protocolLevel: MQTTProtocolVersion = .version311,
         userProperties: [String: String]? = nil,
+        alpn: [String]? = nil,
         connectHandler: MQTTConnectHandler? = nil) {
         printDebug("MQTT - COURIER: Client Session Manager connect to: \(host)")
         let shouldReconnect = self.session != nil
@@ -154,7 +157,8 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
             Int(lastWillQoS?.rawValue ?? 0) != self.willQoS ||
             lastWillRetainFlag != self.willRetainFlag ||
             clientId != self.clientId ||
-            securityPolicy != self.securityPolicy {
+            securityPolicy != self.securityPolicy ||
+            alpn != self.alpn {
             self.host = host
             self.port = UInt32(port)
             self.tls = isTls
@@ -172,6 +176,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
             self.securityPolicy = securityPolicy
             self.certificates = certificates
             self.protocolLevel = protocolLevel
+            self.alpn = alpn
 
             self.session = mqttSessionFactory.makeSession()
             session?.clientId = clientId
@@ -256,6 +261,9 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
             transport = securityTransport
         } else {
             transport = MQTTCFSocketTransport()
+        }
+        if let alpn = alpn {
+            transport.alpn = alpn
         }
         transport.host = host
         transport.port = port

--- a/CourierTests/Core/Mocks/MockMQTTClientFrameworkSessionManager.swift
+++ b/CourierTests/Core/Mocks/MockMQTTClientFrameworkSessionManager.swift
@@ -37,8 +37,8 @@ class MockMQTTClientFrameworkSessionManager: IMQTTClientFrameworkSessionManager 
 
     var invokedConnect = false
     var invokedConnectCount = 0
-    var invokedConnectParameters: (host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, connectHandler: MQTTConnectHandler?)?
-    var invokedConnectParametersList = [(host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, connectHandler: MQTTConnectHandler?)]()
+    var invokedConnectParameters: (host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, alpn: [String]?, connectHandler: MQTTConnectHandler?)?
+    var invokedConnectParametersList = [(host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, alpn: [String]?, connectHandler: MQTTConnectHandler?)]()
 
     func connect(
         to host: String,
@@ -58,11 +58,12 @@ class MockMQTTClientFrameworkSessionManager: IMQTTClientFrameworkSessionManager 
         certificates: [Any]?,
         protocolLevel: MQTTProtocolVersion,
         userProperties: [String: String]?,
+        alpn: [String]?,
         connectHandler: MQTTConnectHandler?) {
         invokedConnect = true
         invokedConnectCount += 1
-        invokedConnectParameters = (host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, connectHandler)
-        invokedConnectParametersList.append((host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, connectHandler))
+        invokedConnectParameters = (host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, alpn, connectHandler)
+        invokedConnectParametersList.append((host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, alpn, connectHandler))
     }
 
     var invokedDisconnect = false

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCFSocketTransport.h
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCFSocketTransport.h
@@ -36,6 +36,10 @@
  */
 @property (nonatomic) BOOL tls;
 
+/** ALPN to use, default to not use ALPN
+ */
+@property (strong, nonatomic) NSArray *alpn;
+
 /** Require for VoIP background service
  * defaults to NO
  */

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCFSocketTransport.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCFSocketTransport.m
@@ -24,12 +24,14 @@
 @synthesize streamSSLLevel;
 @synthesize host;
 @synthesize port;
+@synthesize alpn;
 
 - (instancetype)init {
     self = [super init];
     self.host = @"localhost";
     self.port = 1883;
     self.tls = false;
+    self.alpn = nil;
     self.voip = false;
     self.certificates = nil;
     self.queue = dispatch_get_main_queue();


### PR DESCRIPTION
This MR added supports for passing ALPN array string in ConnectOptions. It can be used to connect to AWS IoT MQTT host with port 443