### PR TITLE
Delay CoreData Context initialization in serial queue async call

### DIFF
--- a/CourierMQTT/MQTT/Client/MQTTClient.swift
+++ b/CourierMQTT/MQTT/Client/MQTTClient.swift
@@ -4,11 +4,9 @@ import Reachability
 
 class MQTTClient: IMQTTClient {
     let connection: IMQTTConnection
-    private var _connectOptions = Atomic<ConnectOptions?>(nil)
-    private(set) var connectOptions: ConnectOptions? {
-        get { _connectOptions.value }
-        set { _connectOptions.mutate { $0 = newValue } }
-    }
+
+    @Atomic<ConnectOptions?>(nil) private(set) var connectOptions
+
     private(set) var isInitialized = false
     private let eventHandler: ICourierEventHandler
 

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTPersistence.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTPersistence.swift
@@ -25,10 +25,6 @@ struct MQTTPersistenceFactory: IMQTTPersistenceFactory {
         persistence.maxWindowSize = UInt(self.maxWindowSize)
         persistence.maxSize = UInt(self.maxSize)
         persistence.maxMessages = UInt(self.maxMessages)
-        
-        if shouldInitializeCoreDataPersistenceContext {
-            persistence.initializeManagedObjectContext()
-        }
         return persistence
     }
 }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -18,11 +18,7 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
     private let connectionConfig: ConnectionConfig
     private(set) var messageReceiveListener: IMessageReceiveListener?
     
-    private var _connectOptions = Atomic<ConnectOptions?>(nil)
-    private(set) var connectOptions: ConnectOptions? {
-        get { _connectOptions.value }
-        set { _connectOptions.mutate { $0 = newValue } }
-    }
+    @Atomic<ConnectOptions?>(nil) private(set) var connectOptions
 
     private(set) var lastPing: Date?
     private(set) var lastPong: Date?

--- a/CourierMQTT/Utils/Atomic.swift
+++ b/CourierMQTT/Utils/Atomic.swift
@@ -1,18 +1,29 @@
 import Foundation
 
+@propertyWrapper
 final class Atomic<T> {
-    private let dispatchQueue = DispatchQueue(label: "courier.courier.atomic", attributes: .concurrent)
+    private let dispatchQueue: DispatchQueue
     private var _value: T
-    init(_ value: T) {
+
+    init(_ value: T, dispatchQueueLabel: String = "courier.courier.atomic") {
+        dispatchQueue = DispatchQueue(label: dispatchQueueLabel, attributes: .concurrent)
         self._value = value
     }
-
-    var value: T { dispatchQueue.sync { _value } }
-
+    
+    var wrappedValue: T {
+        get { dispatchQueue.sync { _value } }
+        set {
+            dispatchQueue.async(flags: .barrier) {
+                self._value = newValue
+            }
+        }
+    }
+    
     func mutate(execute task: (inout T) -> Void) {
         dispatchQueue.sync(flags: .barrier) { task(&_value) }
     }
-
+    
+    
     func mapValue<U>(handler: ((T) -> U)) -> U {
         dispatchQueue.sync { handler(_value) }
     }

--- a/CourierMQTT/Utils/MulticastDelegate.swift
+++ b/CourierMQTT/Utils/MulticastDelegate.swift
@@ -3,18 +3,18 @@ import Foundation
 
 class MulticastDelegate<T> {
 
-    private let atomic = Atomic<NSHashTable<AnyObject>>(NSHashTable.weakObjects())
+    @Atomic<NSHashTable<AnyObject>>(NSHashTable.weakObjects()) private(set) var atomic
 
     private var delegates: [AnyObject] {
-        atomic.mapValue { $0.allObjects.reversed() }
+        _atomic.mapValue { $0.allObjects.reversed() }
     }
 
     func add(_ delegate: T) {
-        atomic.mutate { $0.add(delegate as AnyObject) }
+        _atomic.mutate { $0.add(delegate as AnyObject) }
     }
 
     func remove(_ delegateToRemove: T) {
-        atomic.mutate { $0.remove(delegateToRemove as AnyObject) }
+        _atomic.mutate { $0.remove(delegateToRemove as AnyObject) }
     }
 
     func invoke(_ invocation: @escaping (T) -> Void) {

--- a/CourierTests/Core/MQTT/Message/MQTTMessageReceiveListenerTests.swift
+++ b/CourierTests/Core/MQTT/Message/MQTTMessageReceiveListenerTests.swift
@@ -78,7 +78,6 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
         XCTAssertTrue(mockMessagePersistence.invokedDeleteAllMessages)
     }
     
-    
     func testOnMessageArrivedWithIncomingMessagePersistenceEnabled() {
         let exp = expectation(description: "messageArrivedIncomingMessagePersistence")
         let exp2 = expectation(description: "messageArrivedIncomingMessagePersistence2")
@@ -87,9 +86,7 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
 
         sut = MqttMessageReceiverListener(publishSubject: publishSubject, publishSubjectDispatchQueue: dispatchQueue, incomingMessagePersistence: mockMessagePersistence, messagePersistenceTTLSeconds: 30, messageCleanupInterval: 0.5)
         mockMessagePersistence.stubbedGetAllMessagesResult = [MQTTPacket(data: data, topic: "fbon", qos: .two)]
-        sut.messagePublisherDict.mutate { dict in
-            dict["fbon", default: 0] += 1
-        }
+        sut.messagePublisherDict["fbon", default: 0] += 1
                 
         publishSubject
             .asObservable()
@@ -103,7 +100,6 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
             }
             .disposed(by: disposeBag)
         
-        
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             XCTAssertTrue(self.mockMessagePersistence.invokedDeleteMessages)
             XCTAssertTrue(self.mockMessagePersistence.invokedDeleteMessagesWithOlderTimestamp)
@@ -116,4 +112,3 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
     }
     
 }
-

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTCoreDataPersistence.m
@@ -198,9 +198,11 @@
 
 - (NSManagedObjectContext *)managedObjectContext {
     if (!_managedObjectContext) {
-        NSPersistentStoreCoordinator *coordinator = [self createPersistentStoreCoordinator];
-        _managedObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-       _managedObjectContext.persistentStoreCoordinator = coordinator;
+        @synchronized (self) {
+            NSPersistentStoreCoordinator *coordinator = [self createPersistentStoreCoordinator];
+            _managedObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+           _managedObjectContext.persistentStoreCoordinator = coordinator;
+        }
     }
     return _managedObjectContext;
 }


### PR DESCRIPTION
To avoid blocking the initialization of Courier because of Core Data. This MR implements:
- Invoke serial queue async call to initialize core data
-  This MR also updates Atomic to use Property Wrapper implmentation
-  Add Atomic to ReconnectTimer in MQTTCourierClient to avoid race condition crashes