### PR TITLE
Add Content-Type to Message Adapter

### DIFF
--- a/CourierMQTT/MQTT/Message/Adapters/DataMessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/DataMessageAdapter.swift
@@ -7,14 +7,14 @@ public struct DataMessageAdapter: MessageAdapter {
     
     public init() {}
 
-    public func fromMessage<T>(_ message: Data) throws -> T {
+    public func fromMessage<T>(_ message: Data, topic: String) throws -> T {
         if let value = message as? T {
             return value
         }
         throw CourierError.decodingError.asNSError
     }
 
-    public func toMessage<T>(data: T) throws -> Data {
+    public func toMessage<T>(data: T, topic: String) throws -> Data {
         if let _data = data as? Data {
             return _data
         }

--- a/CourierMQTT/MQTT/Message/Adapters/DataMessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/DataMessageAdapter.swift
@@ -3,6 +3,8 @@ import Foundation
 
 public struct DataMessageAdapter: MessageAdapter {
 
+    public var contentType: String { "application/octet-stream" }
+    
     public init() {}
 
     public func fromMessage<T>(_ message: Data) throws -> T {

--- a/CourierMQTT/MQTT/Message/Adapters/JSONMessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/JSONMessageAdapter.swift
@@ -14,7 +14,7 @@ public struct JSONMessageAdapter: MessageAdapter {
         self.jsonEncoder = jsonEncoder
     }
 
-    public func fromMessage<T>(_ message: Data) throws -> T {
+    public func fromMessage<T>(_ message: Data, topic: String) throws -> T {
         if let decodableType = T.self as? Decodable.Type,
            let value = try decodableType.init(data: message, jsonDecoder: jsonDecoder) as? T {
             return value
@@ -22,7 +22,7 @@ public struct JSONMessageAdapter: MessageAdapter {
         throw CourierError.decodingError.asNSError
     }
 
-    public func toMessage<T>(data: T) throws -> Data {
+    public func toMessage<T>(data: T, topic: String) throws -> Data {
         guard !(data is Data) else {
             throw CourierError.encodingError.asNSError
         }

--- a/CourierMQTT/MQTT/Message/Adapters/JSONMessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/JSONMessageAdapter.swift
@@ -5,6 +5,8 @@ public struct JSONMessageAdapter: MessageAdapter {
 
     private let jsonDecoder: JSONDecoder
     private let jsonEncoder: JSONEncoder
+    
+    public var contentType: String { "application/json" }
 
     public init(jsonDecoder: JSONDecoder = JSONDecoder(),
                 jsonEncoder: JSONEncoder = JSONEncoder()) {

--- a/CourierMQTT/MQTT/Message/Adapters/MessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/MessageAdapter.swift
@@ -4,7 +4,7 @@ public protocol MessageAdapter {
     
     var contentType: String { get }
 
-    func fromMessage<T>(_ message: Data) throws -> T
+    func fromMessage<T>(_ message: Data, topic: String) throws -> T
 
-    func toMessage<T>(data: T) throws -> Data
+    func toMessage<T>(data: T, topic: String) throws -> Data
 }

--- a/CourierMQTT/MQTT/Message/Adapters/MessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/MessageAdapter.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public protocol MessageAdapter {
+    
+    var contentType: String { get }
 
     func fromMessage<T>(_ message: Data) throws -> T
 

--- a/CourierMQTT/MQTT/Message/Adapters/PlistMessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/PlistMessageAdapter.swift
@@ -13,7 +13,7 @@ public struct PlistMessageAdapter: MessageAdapter {
         self.plistEncoder = plistEncoder
     }
 
-    public func fromMessage<T>(_ message: Data) throws -> T {
+    public func fromMessage<T>(_ message: Data, topic: String) throws -> T {
         if let decodableType = T.self as? Decodable.Type,
            let value = try decodableType.init(data: message, plistDecoder: plistDecoder) as? T {
             return value
@@ -21,7 +21,7 @@ public struct PlistMessageAdapter: MessageAdapter {
         throw CourierError.decodingError.asNSError
     }
 
-    public func toMessage<T>(data: T) throws -> Data {
+    public func toMessage<T>(data: T, topic: String) throws -> Data {
         if let encodable = data as? Encodable {
             return try encodable.encode(plistEncoder: plistEncoder)
         }

--- a/CourierMQTT/MQTT/Message/Adapters/PlistMessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/PlistMessageAdapter.swift
@@ -4,6 +4,8 @@ import Foundation
 public struct PlistMessageAdapter: MessageAdapter {
     private let plistDecoder: PropertyListDecoder
     private let plistEncoder: PropertyListEncoder
+    
+    public var contentType: String { "application/xml" }
 
     public init(plistDecoder: PropertyListDecoder = PropertyListDecoder(),
                 plistEncoder: PropertyListEncoder = PropertyListEncoder()) {

--- a/CourierMQTT/MQTT/Message/Adapters/TextMessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/TextMessageAdapter.swift
@@ -7,7 +7,7 @@ public struct TextMessageAdapter: MessageAdapter {
     
     public init() {}
 
-    public func fromMessage<T>(_ message: Data) throws -> T {
+    public func fromMessage<T>(_ message: Data, topic: String) throws -> T {
         if let stringType = T.self as? String.Type,
            let value = stringType.init(data: message, encoding: .utf8) as? T {
             return value
@@ -15,7 +15,7 @@ public struct TextMessageAdapter: MessageAdapter {
         throw CourierError.decodingError.asNSError
     }
 
-    public func toMessage<T>(data: T) throws -> Data {
+    public func toMessage<T>(data: T, topic: String) throws -> Data {
         if let string = data as? String,
            let data = string.data(using: .utf8) {
             return data

--- a/CourierMQTT/MQTT/Message/Adapters/TextMessageAdapter.swift
+++ b/CourierMQTT/MQTT/Message/Adapters/TextMessageAdapter.swift
@@ -3,6 +3,8 @@ import Foundation
 
 public struct TextMessageAdapter: MessageAdapter {
 
+    public var contentType: String { "text/plain" }
+    
     public init() {}
 
     public func fromMessage<T>(_ message: Data) throws -> T {

--- a/CourierMQTT/MQTT/Message/MessageAdaptersCoordinator.swift
+++ b/CourierMQTT/MQTT/Message/MessageAdaptersCoordinator.swift
@@ -5,10 +5,10 @@ struct MessageAdaptersCoordinator {
 
     let messageAdapters: [MessageAdapter]
 
-    func decodeMessage<D>(_ data: Data) -> D? {
+    func decodeMessage<D>(_ data: Data, topic: String) -> D? {
         for adapter in messageAdapters {
             do {
-                let decoded: D = try adapter.fromMessage(data)
+                let decoded: D = try adapter.fromMessage(data, topic: topic)
                 return decoded
             } catch {
                 printDebug(error.localizedDescription)
@@ -17,9 +17,9 @@ struct MessageAdaptersCoordinator {
         return nil
     }
 
-    func encodeMessage<E>(_ data: E) throws -> Data {
+    func encodeMessage<E>(_ data: E, topic: String) throws -> Data {
         for adapter in messageAdapters {
-            if let encoded = try? adapter.toMessage(data: data) {
+            if let encoded = try? adapter.toMessage(data: data, topic: topic) {
                 return encoded
             }
         }

--- a/CourierProtobuf/ProtobufMessageAdapter.swift
+++ b/CourierProtobuf/ProtobufMessageAdapter.swift
@@ -7,7 +7,7 @@ public class ProtobufMessageAdapter: MessageAdapter {
     public var contentType: String { "application/x-protobuf" }
 
     public init() {}
-    public func fromMessage<T>(_ message: Data, topic: String) throws -> T {
+    public func fromMessage<T>(_ message: Data) throws -> T {
         if let decodableType = T.self as? SwiftProtobuf.Message.Type,
            let value = try decodableType.init(serializedData: message) as? T {
             return value
@@ -15,7 +15,7 @@ public class ProtobufMessageAdapter: MessageAdapter {
         throw CourierError.decodingError.asNSError
     }
 
-    public func toMessage<T>(data: T, topic: String) throws -> Data {
+    public func toMessage<T>(data: T) throws -> Data {
         if let encodable = data as? SwiftProtobuf.Message {
             return try encodable.serializedData()
         }

--- a/CourierProtobuf/ProtobufMessageAdapter.swift
+++ b/CourierProtobuf/ProtobufMessageAdapter.swift
@@ -7,7 +7,7 @@ public class ProtobufMessageAdapter: MessageAdapter {
     public var contentType: String { "application/x-protobuf" }
 
     public init() {}
-    public func fromMessage<T>(_ message: Data) throws -> T {
+    public func fromMessage<T>(_ message: Data, topic: String) throws -> T {
         if let decodableType = T.self as? SwiftProtobuf.Message.Type,
            let value = try decodableType.init(serializedData: message) as? T {
             return value
@@ -15,7 +15,7 @@ public class ProtobufMessageAdapter: MessageAdapter {
         throw CourierError.decodingError.asNSError
     }
 
-    public func toMessage<T>(data: T) throws -> Data {
+    public func toMessage<T>(data: T, topic: String) throws -> Data {
         if let encodable = data as? SwiftProtobuf.Message {
             return try encodable.serializedData()
         }

--- a/CourierProtobuf/ProtobufMessageAdapter.swift
+++ b/CourierProtobuf/ProtobufMessageAdapter.swift
@@ -3,9 +3,11 @@ import CourierMQTT
 import SwiftProtobuf
 
 public class ProtobufMessageAdapter: MessageAdapter {
+    
+    public var contentType: String { "application/x-protobuf" }
 
     public init() {}
-    public func fromMessage<T>(_ message: Data) throws -> T {
+    public func fromMessage<T>(_ message: Data, topic: String) throws -> T {
         if let decodableType = T.self as? SwiftProtobuf.Message.Type,
            let value = try decodableType.init(serializedData: message) as? T {
             return value
@@ -13,7 +15,7 @@ public class ProtobufMessageAdapter: MessageAdapter {
         throw CourierError.decodingError.asNSError
     }
 
-    public func toMessage<T>(data: T) throws -> Data {
+    public func toMessage<T>(data: T, topic: String) throws -> Data {
         if let encodable = data as? SwiftProtobuf.Message {
             return try encodable.serializedData()
         }

--- a/CourierTests/Core/MQTT/Message/DataMessageAdapterTests.swift
+++ b/CourierTests/Core/MQTT/Message/DataMessageAdapterTests.swift
@@ -18,4 +18,8 @@ class DataMessageAdapterTests: XCTestCase {
         let test = "test".data(using: .utf8)!
         XCTAssertNoThrow(try sut.toMessage(data: test))
     }
+    
+    func testContentType() {
+        XCTAssertEqual(sut.contentType, "application/octet-stream")
+    }
 }

--- a/CourierTests/Core/MQTT/Message/DataMessageAdapterTests.swift
+++ b/CourierTests/Core/MQTT/Message/DataMessageAdapterTests.swift
@@ -11,12 +11,12 @@ class DataMessageAdapterTests: XCTestCase {
 
     func testFromMessage() {
         let test = "test".data(using: .utf8)!
-        XCTAssertEqual(test, try! sut.fromMessage(test))
+        XCTAssertEqual(test, try! sut.fromMessage(test, topic: "x"))
     }
 
     func testToMessage() {
         let test = "test".data(using: .utf8)!
-        XCTAssertNoThrow(try sut.toMessage(data: test))
+        XCTAssertNoThrow(try sut.toMessage(data: test, topic: "x"))
     }
     
     func testContentType() {

--- a/CourierTests/Core/MQTT/Message/JSONMessageAdapterTests.swift
+++ b/CourierTests/Core/MQTT/Message/JSONMessageAdapterTests.swift
@@ -16,14 +16,14 @@ class JSONMessageAdapterTests: XCTestCase {
 
     func testFromMessage() {
         let person = Person(name: "henry")
-        let data = try! sut.toMessage(data: person)
-        let result: Person = try! sut.fromMessage(data)
+        let data = try! sut.toMessage(data: person, topic: "x")
+        let result: Person = try! sut.fromMessage(data, topic: "x")
         XCTAssertEqual(result.name, person.name)
     }
 
     func testToMessage() {
         let person = Person(name: "henry")
-        XCTAssertNoThrow(try sut.toMessage(data: person))
+        XCTAssertNoThrow(try sut.toMessage(data: person, topic: "x"))
     }
     
     func testContentType() {

--- a/CourierTests/Core/MQTT/Message/JSONMessageAdapterTests.swift
+++ b/CourierTests/Core/MQTT/Message/JSONMessageAdapterTests.swift
@@ -25,4 +25,8 @@ class JSONMessageAdapterTests: XCTestCase {
         let person = Person(name: "henry")
         XCTAssertNoThrow(try sut.toMessage(data: person))
     }
+    
+    func testContentType() {
+        XCTAssertEqual(sut.contentType, "application/json")
+    }
 }

--- a/CourierTests/Core/MQTT/Message/MessageAdaptersCoordinatorTests.swift
+++ b/CourierTests/Core/MQTT/Message/MessageAdaptersCoordinatorTests.swift
@@ -16,10 +16,10 @@ class MessageAdaptersCoordinatorsTests: XCTestCase {
         let henryAsJSONData = try! JSONEncoder().encode(Person(name: "HENRY"))
         let dennisAsPlistData = try! PropertyListEncoder().encode(Person(name: "DENNIS"))
 
-        let dennis: Person? = sut.decodeMessage(dennisAsPlistData)
+        let dennis: Person? = sut.decodeMessage(dennisAsPlistData, topic: "x")
         XCTAssertEqual(dennis?.name, "DENNIS")
 
-        let henry: Person? = sut.decodeMessage(henryAsJSONData)
+        let henry: Person? = sut.decodeMessage(henryAsJSONData, topic: "x")
         XCTAssertEqual(henry?.name, "HENRY")
     }
 
@@ -27,7 +27,7 @@ class MessageAdaptersCoordinatorsTests: XCTestCase {
         setupJSONAndPlistMessageAdapters()
 
         let henry = Person(name: "Henry")
-        let data = try! sut.encodeMessage(henry)
+        let data = try! sut.encodeMessage(henry, topic: "x")
 
         XCTAssertNoThrow(try JSONSerialization.jsonObject(with: data, options: .mutableContainers))
     }

--- a/CourierTests/Core/MQTT/Message/PlistMessageAdapterTests.swift
+++ b/CourierTests/Core/MQTT/Message/PlistMessageAdapterTests.swift
@@ -24,4 +24,8 @@ class PlistMessageAdapterTests: XCTestCase {
         let person = Person(name: "henry")
         XCTAssertNoThrow(try sut.toMessage(data: person))
     }
+    
+    func testContentType() {
+        XCTAssertEqual(sut.contentType, "application/xml")
+    }
 }

--- a/CourierTests/Core/MQTT/Message/PlistMessageAdapterTests.swift
+++ b/CourierTests/Core/MQTT/Message/PlistMessageAdapterTests.swift
@@ -15,14 +15,14 @@ class PlistMessageAdapterTests: XCTestCase {
 
     func testFromMessage() {
         let person = Person(name: "henry")
-        let data = try! sut.toMessage(data: person)
-        let result: Person = try! sut.fromMessage(data)
+        let data = try! sut.toMessage(data: person, topic: "x")
+        let result: Person = try! sut.fromMessage(data, topic: "x")
         XCTAssertEqual(result.name, person.name)
     }
 
     func testToMessage() {
         let person = Person(name: "henry")
-        XCTAssertNoThrow(try sut.toMessage(data: person))
+        XCTAssertNoThrow(try sut.toMessage(data: person, topic: "x"))
     }
     
     func testContentType() {

--- a/CourierTests/Core/MQTT/Message/TextMessageAdapterTests.swift
+++ b/CourierTests/Core/MQTT/Message/TextMessageAdapterTests.swift
@@ -11,13 +11,13 @@ class TextMessageAdapterTests: XCTestCase {
 
     func testFromMessage() {
         let name = "hiro"
-        let result: String = try! sut.fromMessage(name.data(using: .utf8)!)
+        let result: String = try! sut.fromMessage(name.data(using: .utf8)!, topic: "x")
         XCTAssertEqual(result, "hiro")
     }
 
     func testToMessage() {
         let name = "hiro"
-        let convertedData = try! sut.toMessage(data: name)
+        let convertedData = try! sut.toMessage(data: name, topic: "x")
         XCTAssertEqual("hiro", String(data: convertedData, encoding: .utf8))
     }
     

--- a/CourierTests/Core/MQTT/Message/TextMessageAdapterTests.swift
+++ b/CourierTests/Core/MQTT/Message/TextMessageAdapterTests.swift
@@ -20,4 +20,9 @@ class TextMessageAdapterTests: XCTestCase {
         let convertedData = try! sut.toMessage(data: name)
         XCTAssertEqual("hiro", String(data: convertedData, encoding: .utf8))
     }
+    
+    func testContentType() {
+        XCTAssertEqual(sut.contentType, "text/plain")
+    }
+    
 }

--- a/CourierTests/Core/Mocks/MockMessageAdapter.swift
+++ b/CourierTests/Core/Mocks/MockMessageAdapter.swift
@@ -1,7 +1,18 @@
 import Foundation
 @testable import CourierCore
 @testable import CourierMQTT
+
 class MockMessageAdapter: MessageAdapter {
+
+    var invokedContentTypeGetter = false
+    var invokedContentTypeGetterCount = 0
+    var stubbedContentType: String! = ""
+
+    var contentType: String {
+        invokedContentTypeGetter = true
+        invokedContentTypeGetterCount += 1
+        return stubbedContentType
+    }
 
     var invokedFromMessage = false
     var invokedFromMessageCount = 0

--- a/CourierTests/Core/Mocks/MockMessageAdapter.swift
+++ b/CourierTests/Core/Mocks/MockMessageAdapter.swift
@@ -16,16 +16,16 @@ class MockMessageAdapter: MessageAdapter {
 
     var invokedFromMessage = false
     var invokedFromMessageCount = 0
-    var invokedFromMessageParameters: (message: Data, Void)?
-    var invokedFromMessageParametersList = [(message: Data, Void)]()
+    var invokedFromMessageParameters: (message: Data, topic: String)?
+    var invokedFromMessageParametersList = [(message: Data, topic: String)]()
     var stubbedFromMessageError: Error?
     var stubbedFromMessageResult: Any!
 
-    func fromMessage<T>(_ message: Data) throws -> T {
+    func fromMessage<T>(_ message: Data, topic: String) throws -> T {
         invokedFromMessage = true
         invokedFromMessageCount += 1
-        invokedFromMessageParameters = (message, ())
-        invokedFromMessageParametersList.append((message, ()))
+        invokedFromMessageParameters = (message, topic)
+        invokedFromMessageParametersList.append((message, topic))
         if let error = stubbedFromMessageError {
             throw error
         }
@@ -34,16 +34,16 @@ class MockMessageAdapter: MessageAdapter {
 
     var invokedToMessage = false
     var invokedToMessageCount = 0
-    var invokedToMessageParameters: (data: Any, Void)?
-    var invokedToMessageParametersList = [(data: Any, Void)]()
+    var invokedToMessageParameters: (data: Any, topic: String)?
+    var invokedToMessageParametersList = [(data: Any, topic: String)]()
     var stubbedToMessageError: Error?
     var stubbedToMessageResult: Data!
 
-    func toMessage<T>(data: T) throws -> Data {
+    func toMessage<T>(data: T, topic: String) throws -> Data {
         invokedToMessage = true
         invokedToMessageCount += 1
-        invokedToMessageParameters = (data, ())
-        invokedToMessageParametersList.append((data, ()))
+        invokedToMessageParameters = (data, topic)
+        invokedToMessageParametersList.append((data, topic))
         if let error = stubbedToMessageError {
             throw error
         }

--- a/CourierTests/ProtobufMessageAdapter/ProtobufMessageAdapterTests.swift
+++ b/CourierTests/ProtobufMessageAdapter/ProtobufMessageAdapterTests.swift
@@ -28,6 +28,10 @@ class ProtobufMessageAdapterTests: XCTestCase {
         XCTAssertEqual(decodedNote.title, note.title)
         XCTAssertEqual(decodedNote.content, note.content)
     }
+    
+    func testContentType() {
+        XCTAssertEqual(sut.contentType, "application/x-protobuf")
+    }
 
 }
 

--- a/CourierTests/ProtobufMessageAdapter/ProtobufMessageAdapterTests.swift
+++ b/CourierTests/ProtobufMessageAdapter/ProtobufMessageAdapterTests.swift
@@ -15,16 +15,16 @@ class ProtobufMessageAdapterTests: XCTestCase {
         let note = stubbedNote(title: "x", content: "y")
         let data = try! note.serializedData()
 
-        let decodedNote: Note = try! sut.fromMessage(data)
+        let decodedNote: Note = try! sut.fromMessage(data, topic: "x")
         XCTAssertEqual(decodedNote.title, note.title)
         XCTAssertEqual(decodedNote.content, note.content)
     }
 
     func testProtoDataSerialization() {
         let note = stubbedNote(title: "x", content: "y")
-        let encodedData = try! sut.toMessage(data: note)
+        let encodedData = try! sut.toMessage(data: note, topic: "x")
 
-        let decodedNote: Note = try! sut.fromMessage(encodedData)
+        let decodedNote: Note = try! sut.fromMessage(encodedData, topic: "x")
         XCTAssertEqual(decodedNote.title, note.title)
         XCTAssertEqual(decodedNote.content, note.content)
     }


### PR DESCRIPTION
Add Content-Type requirement for Message Adapter Protocol. It is expected to return a string based on Common HTTP MIME Content-Type https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types