### PR TITLE
Courier Events - Add TimeTaken Prop and other missing props

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -4,5 +4,5 @@ set -eo pipefail
 
 xcodebuild -workspace Courier.xcworkspace \
     -scheme CourierTests \
-    -destination platform=iOS\ Simulator,OS=15.2,name=iPhone\ 13 \
+    -destination platform=iOS\ Simulator,OS=16.0,name=iPhone\ 13 \
     clean test | xcpretty

--- a/Courier.xcodeproj/project.pbxproj
+++ b/Courier.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		B0DA90E6285739A000F6512D /* libCourierMQTT.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE0DD6D270BE47300630D60 /* libCourierMQTT.a */; };
 		B0DA90E9285739A000F6512D /* libCourierProtobuf.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE0DFEA270BE85B00630D60 /* libCourierProtobuf.a */; };
 		B0DA90EC285739A000F6512D /* libMQTTClientGJ.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B9A803927DAFB9500732992 /* libMQTTClientGJ.a */; };
+		B0DC1BD6292F39EB000BB593 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DC1BD5292F39EB000BB593 /* Date+Extension.swift */; };
 		BD64D90B9161917798603676 /* Pods_CourierTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01E4C0FB47EC974550D736E3 /* Pods_CourierTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -634,6 +635,7 @@
 		B0DA90B82856F5E300F6512D /* CourierE2EApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourierE2EApp.swift; sourceTree = "<group>"; };
 		B0DA90BC2856F5E400F6512D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B0DA90BF2856F5E400F6512D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		B0DC1BD5292F39EB000BB593 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		B2A539B4CC71894E7F9786CB /* Pods-ProtobufMessageAdapter.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProtobufMessageAdapter.production.xcconfig"; path = "Target Support Files/Pods-ProtobufMessageAdapter/Pods-ProtobufMessageAdapter.production.xcconfig"; sourceTree = "<group>"; };
 		B34A10F81E34FB8483FD5528 /* Pods-CourierMQTT.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CourierMQTT.release.xcconfig"; path = "Target Support Files/Pods-CourierMQTT/Pods-CourierMQTT.release.xcconfig"; sourceTree = "<group>"; };
 		BCF0DEB7D3AF7421867F8965 /* Pods_CourierE2EApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CourierE2EApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1110,6 +1112,7 @@
 				8BE0DEEE270BE50700630D60 /* Error */,
 				8BE0DEF0270BE50700630D60 /* Event */,
 				8BE0DEF4270BE50700630D60 /* Client */,
+				B0DC1BD5292F39EB000BB593 /* Date+Extension.swift */,
 			);
 			path = MQTT;
 			sourceTree = "<group>";
@@ -2133,6 +2136,7 @@
 				8BE0DFAB270BE50A00630D60 /* Producer.swift in Sources */,
 				8BE0DFB7270BE50A00630D60 /* Just.swift in Sources */,
 				8BE0DF8F270BE50900630D60 /* MQTTClient.swift in Sources */,
+				B0DC1BD6292F39EB000BB593 /* Date+Extension.swift in Sources */,
 				8BE0DF8D270BE50900630D60 /* ICourierEventHandlerFactory.swift in Sources */,
 				8BE0DF66270BE50900630D60 /* IMQTTPersistence.swift in Sources */,
 				8BE0DF8C270BE50900630D60 /* MQTTError.swift in Sources */,

--- a/CourierCore/Events/CourierEvent.swift
+++ b/CourierCore/Events/CourierEvent.swift
@@ -27,8 +27,8 @@ public enum CourierEventType {
     case connectDiscarded(reason: String)
 
     case subscribeAttempt(topics: [String])
-    case unsubscribeAttempt(topic: [String])
-    case subscribeSuccess(topis: [(topic: String, qos: QoS)], timeTaken: Int)
+    case unsubscribeAttempt(topics: [String])
+    case subscribeSuccess(topics: [(topic: String, qos: QoS)], timeTaken: Int)
     case unsubscribeSuccess(topics: [String], timeTaken: Int)
     case subscribeFailure(topics: [(topic: String, qos: QoS)], timeTaken: Int, error: Error?)
     case unsubscribeFailure(topics: [String], timeTaken: Int, error: Error?)

--- a/CourierCore/Events/CourierEvent.swift
+++ b/CourierCore/Events/CourierEvent.swift
@@ -12,26 +12,26 @@ public struct CourierEvent {
 
 public enum CourierEventType {
 
-    case connectionServiceAuthStart(source: String? = nil)
-    case connectionServiceAuthSuccess(host: String, port: Int)
-    case connectionServiceAuthFailure(error: Error?)
+    case connectionServiceAuthStart
+    case connectionServiceAuthSuccess(timeTaken: Int)
+    case connectionServiceAuthFailure(timeTaken: Int, error: Error?)
     case connectedPacketSent
     case courierDisconnect(clearState: Bool)
 
     case connectionAttempt
-    case connectionSuccess
-    case connectionFailure(error: Error?)
-    case connectionLost(error: Error?, diffLastInbound: Int?, diffLastOutbound: Int?)
+    case connectionSuccess(timeTaken: Int)
+    case connectionFailure(timeTaken: Int, error: Error?)
+    case connectionLost(timeTaken: Int, error: Error?, diffLastInbound: Int?, diffLastOutbound: Int?)
     case connectionDisconnect
     case reconnect
     case connectDiscarded(reason: String)
 
-    case subscribeAttempt(topic: String)
-    case unsubscribeAttempt(topic: String)
-    case subscribeSuccess(topic: String)
-    case unsubscribeSuccess(topic: String)
-    case subscribeFailure(topic: String, error: Error?)
-    case unsubscribeFailure(topic: String, error: Error?)
+    case subscribeAttempt(topics: [String])
+    case unsubscribeAttempt(topic: [String])
+    case subscribeSuccess(topis: [(topic: String, qos: QoS)], timeTaken: Int)
+    case unsubscribeSuccess(topics: [String], timeTaken: Int)
+    case subscribeFailure(topics: [(topic: String, qos: QoS)], timeTaken: Int, error: Error?)
+    case unsubscribeFailure(topics: [String], timeTaken: Int, error: Error?)
 
     case ping(url: String)
     case pongReceived(timeTaken: Int)

--- a/CourierE2EApp/View Models/ConnectionObservableObject.swift
+++ b/CourierE2EApp/View Models/ConnectionObservableObject.swift
@@ -160,6 +160,7 @@ final class ConnectionObservableObject: ObservableObject {
 extension ConnectionObservableObject: ICourierEventHandler {
     
     func onEvent(_ event: CourierEvent) {
+        print("EVENT: \(event.type)")
         switch event.type {
         case .connectionSuccess:
             if connectionServiceProvider.isCleanSession {

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTClientFrameworkFactory.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTClientFrameworkFactory.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CourierCore
 import MQTTClientGJ
 
 protocol IMQTTClientFrameworkFactory {
@@ -8,14 +9,15 @@ protocol IMQTTClientFrameworkFactory {
         dispatchQueue: DispatchQueue,
         delegate: MQTTClientFrameworkSessionManagerDelegate,
         connectTimeoutPolicy: IConnectTimeoutPolicy,
-        idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol
+        idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol,
+        eventHandler: ICourierEventHandler
     ) -> IMQTTClientFrameworkSessionManager
 }
 
 struct MQTTClientFrameworkFactory: IMQTTClientFrameworkFactory {
 
     func makeSessionManager(connectRetryTimePolicy: IConnectRetryTimePolicy, persistenceFactory: IMQTTPersistenceFactory, dispatchQueue: DispatchQueue, delegate: MQTTClientFrameworkSessionManagerDelegate, connectTimeoutPolicy: IConnectTimeoutPolicy,
-                            idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol) -> IMQTTClientFrameworkSessionManager {
+                            idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol, eventHandler: ICourierEventHandler) -> IMQTTClientFrameworkSessionManager {
         guard !MQTTClientcourier.isEmpty else { fatalError("Please use the MQTTClientGJ from courier podspecs") }
 
         let sessionManager = MQTTClientFrameworkSessionManager(
@@ -25,7 +27,8 @@ struct MQTTClientFrameworkFactory: IMQTTClientFrameworkFactory {
             queue: dispatchQueue,
             mqttPersistenceFactory: persistenceFactory,
             connectTimeoutPolicy: connectTimeoutPolicy,
-            idleActivityTimeoutPolicy: idleActivityTimeoutPolicy
+            idleActivityTimeoutPolicy: idleActivityTimeoutPolicy,
+            eventHandler: eventHandler
         )
         sessionManager.delegate = delegate
 

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -78,7 +78,6 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
             securityPolicy?.allowInvalidCertificates = true
         }
 
-        eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .connectionAttempt))
         sessionManager.connect(
             to: connectOptions.host,
             port: port,
@@ -209,9 +208,9 @@ extension MQTTClientFrameworkConnection: MQTTClientFrameworkSessionManagerDelega
 
     func sessionManagerDidReceivePong(_ sessionManager: IMQTTClientFrameworkSessionManager) {
         lastPong = Date()
-        if let lastPing = self.lastPing, let lastPong = self.lastPong {
+        if let lastPing = self.lastPing {
             printDebug("MQTT - COURIER: Pong received at \(Date()), last ping: \(lastPing)")
-            eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .pongReceived(timeTaken: Int(lastPong.timeIntervalSinceNow - lastPing.timeIntervalSinceNow) * 1000)))
+            eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .pongReceived(timeTaken: lastPing.timeTaken)))
         }
         lastPing = nil
     }
@@ -241,7 +240,7 @@ extension MQTTClientFrameworkConnection: MQTTClientFrameworkSessionManagerDelega
 
     func sessionManager(_ sessionManager: IMQTTClientFrameworkSessionManager, didSubscribeTopics topics: [String]) {
         #if DEBUG
-        topics.forEach { printDebug("MQTT - COURIER: Subscribed to \(topic)") }
+        topics.forEach { printDebug("MQTT - COURIER: Subscribed to \($0)") }
         #endif
     }
 

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -18,10 +18,10 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
     private let connectionConfig: ConnectionConfig
     private(set) var messageReceiveListener: IMessageReceiveListener?
     
-    @Atomic<ConnectOptions?>(nil) private(set) var connectOptions
-    @Atomic<Date>(Date()) private(set) var connectionAttemptTimestamp
-    @Atomic<Date?>(nil) private(set) var lastPing
-    @Atomic<Date?>(nil) private(set) var lastPong
+    @Atomic<ConnectOptions?>(nil) var connectOptions
+    @Atomic<Date>(Date()) var connectionAttemptTimestamp
+    @Atomic<Date?>(nil) var lastPing
+    @Atomic<Date?>(nil) var lastPong
     
     var isConnected: Bool { sessionManager?.state == .connected }
     var isConnecting: Bool { sessionManager?.state == .connecting }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -63,7 +63,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
     @Atomic<MQTTSessionManagerState?>(nil) private(set) var state
 
     private(set) var lastError: NSError?
-    private(set) var connectOptions: ConnectOptions?
+    @Atomic<ConnectOptions?>(nil) var connectOptions
 
     private var reconnectTimer: ReconnectTimer?
     private var reconnectFlag = false
@@ -316,7 +316,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
                 self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeFailure(topics: topics, timeTaken: attemptTimestamp.timeTaken, error: error)))
                 self.delegate?.sessionManager(self, didFailToSubscribeTopics: topicsArray, error: error)
             } else {
-                self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeSuccess(topis: topics, timeTaken: attemptTimestamp.timeTaken)))
+                self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeSuccess(topics: topics, timeTaken: attemptTimestamp.timeTaken)))
                 self.delegate?.sessionManager(self, didSubscribeTopics: topicsArray)
             }
         })
@@ -325,7 +325,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
     func unsubscribe(_ topics: [String]) {
         let connectOptions = self.connectOptions
         let attemptTimestamp = Date()
-        
+        eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .unsubscribeAttempt(topics: topics)))
         session?.unsubscribeTopics(topics, unsubscribeHandler: { [weak self] error in
             guard let self = self else { return }
             if let error = error {

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -39,6 +39,7 @@ protocol IMQTTClientFrameworkSessionManager {
         protocolLevel: MQTTProtocolVersion,
         userProperties: [String: String]?,
         alpn: [String]?,
+        connectOptions: ConnectOptions,
         connectHandler: MQTTConnectHandler?)
 
     func disconnect(with disconnectHandler: MQTTDisconnectHandler?)
@@ -57,11 +58,12 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
     weak var delegate: MQTTClientFrameworkSessionManagerDelegate?
     private let persistence: MQTTPersistence
     private let mqttSessionFactory: IMQTTSessionFactory
+    private let eventHandler: ICourierEventHandler
 
-    
     @Atomic<MQTTSessionManagerState?>(nil) private(set) var state
 
     private(set) var lastError: NSError?
+    private(set) var connectOptions: ConnectOptions?
 
     private var reconnectTimer: ReconnectTimer?
     private var reconnectFlag = false
@@ -87,6 +89,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
 
     private var connectTimeoutPolicy: IConnectTimeoutPolicy
     private var idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol
+    
 
     var requiresTeardown: Bool {
         state != .closed && state != .starting
@@ -99,7 +102,8 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
          mqttSessionFactory: IMQTTSessionFactory = MQTTSessionFactory(),
          mqttPersistenceFactory: IMQTTPersistenceFactory = MQTTPersistenceFactory(),
          connectTimeoutPolicy: IConnectTimeoutPolicy,
-         idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol
+         idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol,
+         eventHandler: ICourierEventHandler
     ) {
         self.streamSSLLevel = streamSSLLevel
         self.queue = queue
@@ -107,6 +111,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         self.mqttSessionFactory = mqttSessionFactory
         self.connectTimeoutPolicy = connectTimeoutPolicy
         self.idleActivityTimeoutPolicy = idleActivityTimeoutPolicy
+        self.eventHandler = eventHandler
         
         super.init()
         if let coreDataPersistence = persistence as? MQTTCoreDataPersistence,
@@ -140,8 +145,10 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         protocolLevel: MQTTProtocolVersion = .version311,
         userProperties: [String: String]? = nil,
         alpn: [String]? = nil,
+        connectOptions: ConnectOptions,
         connectHandler: MQTTConnectHandler? = nil) {
         printDebug("MQTT - COURIER: Client Session Manager connect to: \(host)")
+        self.connectOptions = connectOptions
         let shouldReconnect = self.session != nil
         let isTls = port == 443
 
@@ -293,27 +300,39 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
 
     func subscribe(_ topics: [(topic: String, qos: QoS)]) {
         var topicsDict = [String: NSNumber]()
+        var eventTopics: [String] = []
         topics.forEach { topicQoS in
+            eventTopics.append(topicQoS.topic)
             topicsDict[topicQoS.topic] = NSNumber(value: topicQoS.qos.rawValue)
         }
 
+        let connectOptions = self.connectOptions
+        let attemptTimestamp = Date()
+        eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeAttempt(topics: eventTopics)))
         session?.subscribe(toTopics: topicsDict, subscribeHandler: { [weak self] (error, _) in
             guard let self = self else { return }
             let topicsArray = topics.map { $0.topic }
             if let error = error {
+                self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeFailure(topics: topics, timeTaken: attemptTimestamp.timeTaken, error: error)))
                 self.delegate?.sessionManager(self, didFailToSubscribeTopics: topicsArray, error: error)
             } else {
+                self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeSuccess(topis: topics, timeTaken: attemptTimestamp.timeTaken)))
                 self.delegate?.sessionManager(self, didSubscribeTopics: topicsArray)
             }
         })
     }
 
     func unsubscribe(_ topics: [String]) {
+        let connectOptions = self.connectOptions
+        let attemptTimestamp = Date()
+        
         session?.unsubscribeTopics(topics, unsubscribeHandler: { [weak self] error in
             guard let self = self else { return }
             if let error = error {
+                self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .unsubscribeFailure(topics: topics, timeTaken: attemptTimestamp.timeTaken, error: error)))
                 self.delegate?.sessionManager(self, didFailToUnsubscribeTopics: topics, error: error)
             } else {
+                self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .unsubscribeSuccess(topics: topics, timeTaken: attemptTimestamp.timeTaken)))
                 self.delegate?.sessionManager(self, didUnsubscribeTopics: topics)
             }
         })

--- a/CourierMQTT/MQTT/Date+Extension.swift
+++ b/CourierMQTT/MQTT/Date+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  Date+Extension.swift
+//  CourierMQTT
+//
+//  Created by Alfian Losari on 24/11/22.
+//
+
+import Foundation
+
+extension Date {
+    var timeTaken: Int {
+        Int((Date().timeIntervalSince1970 - self.timeIntervalSince1970) * 10000)
+    }
+}
+

--- a/CourierMQTT/MQTT/Date+Extension.swift
+++ b/CourierMQTT/MQTT/Date+Extension.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Date {
     var timeTaken: Int {
-        Int((Date().timeIntervalSince1970 - self.timeIntervalSince1970) * 10000)
+        Int((Date().timeIntervalSince1970 - self.timeIntervalSince1970) * 1000)
     }
 }
 

--- a/CourierMQTT/MQTT/MQTTCourierClient+EventHandler.swift
+++ b/CourierMQTT/MQTT/MQTTCourierClient+EventHandler.swift
@@ -15,8 +15,8 @@ extension MQTTCourierClient: ICourierEventHandler {
             onMQTTConnectionLost()
         case .connectionDisconnect:
             onMQTTDisconnect()
-        case .unsubscribeSuccess(let topic):
-            onMQTTUnsubscribeSuccess(topic: topic)
+        case .unsubscribeSuccess(let topics, _):
+            onMQTTUnsubscribeSuccess(topics: topics)
         case .appForeground:
             onAppForeground()
         case .appBackground:
@@ -56,8 +56,8 @@ extension MQTTCourierClient: ICourierEventHandler {
         publishConnectionState(connectionState)
     }
 
-    private func onMQTTUnsubscribeSuccess(topic: String) {
-        subscriptionStore.unsubscribeAcked([topic])
+    private func onMQTTUnsubscribeSuccess(topics: [String]) {
+        subscriptionStore.unsubscribeAcked(topics)
     }
 
     private func onAppBackground() {

--- a/CourierTests/Core/MQTT/Event/MulticastCourierEventHandlerTests.swift
+++ b/CourierTests/Core/MQTT/Event/MulticastCourierEventHandlerTests.swift
@@ -1,13 +1,7 @@
-
-
-
-
-
-
-
 import XCTest
 @testable import CourierCore
 @testable import CourierMQTT
+
 class MulticastCourierEventHandlerTests: XCTestCase {
 
     var sut: MulticastCourierEventHandler!
@@ -37,11 +31,10 @@ class MulticastCourierEventHandlerTests: XCTestCase {
     }
 
     func testConnectionServiceAuthStart() {
-        sut.onEvent(.init(connectionInfo: nil, event: .connectionServiceAuthStart(source: "TEST")))
+        sut.onEvent(.init(connectionInfo: nil, event: .connectionServiceAuthStart))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case .connectionServiceAuthStart(let source):
+        case .connectionServiceAuthStart:
             XCTAssert(true)
-            XCTAssertEqual(source, "TEST")
         default:
             XCTAssert(false)
         }
@@ -58,23 +51,23 @@ class MulticastCourierEventHandlerTests: XCTestCase {
     }
 
     func testConnectionServiceAuthSuccess() {
-        sut.onEvent(.init(connectionInfo: nil, event: .connectionServiceAuthSuccess(host: "xyz", port: 999)))
+        sut.onEvent(.init(connectionInfo: nil, event: .connectionServiceAuthSuccess(timeTaken: 5)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .connectionServiceAuthSuccess(host, port):
-            XCTAssertEqual(host, "xyz")
-            XCTAssertEqual(port, 999)
+        case let .connectionServiceAuthSuccess(timeTaken):
+            XCTAssertEqual(timeTaken, 5)
         default:
             XCTAssert(false)
         }
     }
 
     func testConnectionServiceAuthFailure() {
-        sut.onEvent(.init(connectionInfo: nil, event: .connectionServiceAuthFailure(error: stubbedError)))
+        sut.onEvent(.init(connectionInfo: nil, event: .connectionServiceAuthFailure(timeTaken: 5, error: stubbedError)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .connectionServiceAuthFailure(error):
+        case let .connectionServiceAuthFailure(timeTaken, error):
             let error = error! as NSError
             XCTAssertEqual(error.domain, stubbedError.domain)
             XCTAssertEqual(error.code, stubbedError.code)
+            XCTAssertEqual(timeTaken, 5)
         default:
             XCTAssert(false)
         }
@@ -101,34 +94,36 @@ class MulticastCourierEventHandlerTests: XCTestCase {
     }
 
     func testConnectionSuccess() {
-        sut.onEvent(.init(connectionInfo: nil, event: .connectionSuccess))
+        sut.onEvent(.init(connectionInfo: nil, event: .connectionSuccess(timeTaken: 5)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case .connectionSuccess:
-            XCTAssert(true)
+        case .connectionSuccess(let timeTaken):
+            XCTAssertEqual(timeTaken, 5)
         default:
             XCTAssert(false)
         }
     }
 
     func testOnConnectionFailure() {
-        sut.onEvent(.init(connectionInfo: nil, event: .connectionFailure(error: stubbedError)))
+        sut.onEvent(.init(connectionInfo: nil, event: .connectionFailure(timeTaken: 5, error: stubbedError)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .connectionFailure(error):
+        case let .connectionFailure(timeTaken, error):
             let error = error! as NSError
             XCTAssertEqual(error.domain, stubbedError.domain)
             XCTAssertEqual(error.code, stubbedError.code)
+            XCTAssertEqual(timeTaken, 5)
         default:
             XCTAssert(false)
         }
     }
 
     func testOnConnectionLost() {
-        sut.onEvent(.init(connectionInfo: nil, event: .connectionLost(error: stubbedError, diffLastInbound: nil, diffLastOutbound: nil)))
+        sut.onEvent(.init(connectionInfo: nil, event: .connectionLost(timeTaken: 5, error: stubbedError, diffLastInbound: nil, diffLastOutbound: nil)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .connectionLost(error, _, _):
+        case let .connectionLost(timeTaken, error, _, _):
             let error = error! as NSError
             XCTAssertEqual(error.domain, stubbedError.domain)
             XCTAssertEqual(error.code, stubbedError.code)
+            XCTAssertEqual(timeTaken, 5)
         default:
             XCTAssert(false)
         }
@@ -156,30 +151,33 @@ class MulticastCourierEventHandlerTests: XCTestCase {
     }
 
     func testOnSubscribeSuccess() {
-        sut.onEvent(.init(connectionInfo: nil, event: .subscribeSuccess(topic: stubbedTopic)))
+        sut.onEvent(.init(connectionInfo: nil, event: .subscribeSuccess(topics: [(stubbedTopic, .zero)], timeTaken: 5)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .subscribeSuccess(topic):
-            XCTAssertEqual(stubbedTopic, topic)
+        case let .subscribeSuccess(topics, timeTaken):
+            XCTAssertEqual(stubbedTopic, topics[0].topic)
+            XCTAssertEqual(timeTaken, 5)
         default:
             XCTAssert(false)
         }
     }
 
     func testOnUnsubscribeSuccess() {
-        sut.onEvent(.init(connectionInfo: nil, event: .unsubscribeSuccess(topic: stubbedTopic)))
+        sut.onEvent(.init(connectionInfo: nil, event: .unsubscribeSuccess(topics: [stubbedTopic], timeTaken: 5)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .unsubscribeSuccess(topic):
-            XCTAssertEqual(stubbedTopic, topic)
+        case let .unsubscribeSuccess(topics, timeTaken):
+            XCTAssertEqual(stubbedTopic, topics[0])
+            XCTAssertEqual(timeTaken, 5)
         default:
             XCTAssert(false)
         }
     }
 
     func testOnSubscribeFailure() {
-        sut.onEvent(.init(connectionInfo: nil, event: .subscribeFailure(topic: stubbedTopic, error: stubbedError)))
+        sut.onEvent(.init(connectionInfo: nil, event: .subscribeFailure(topics: [(stubbedTopic, .zero)], timeTaken: 5, error: stubbedError)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .subscribeFailure(topic, error):
-            XCTAssertEqual(stubbedTopic, topic)
+        case let .subscribeFailure(topics, timeTaken, error):
+            XCTAssertEqual(stubbedTopic, topics[0].topic)
+            XCTAssertEqual(timeTaken, 5)
             let error = error! as NSError
             XCTAssertEqual(error.domain, stubbedError.domain)
             XCTAssertEqual(error.code, stubbedError.code)
@@ -189,10 +187,11 @@ class MulticastCourierEventHandlerTests: XCTestCase {
     }
 
     func testOnUnsubscribeFailure() {
-        sut.onEvent(.init(connectionInfo: nil, event: .unsubscribeFailure(topic: stubbedTopic, error: stubbedError)))
+        sut.onEvent(.init(connectionInfo: nil, event: .unsubscribeFailure(topics: [stubbedTopic], timeTaken: 5, error: stubbedError)))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .unsubscribeFailure(topic, error):
-            XCTAssertEqual(stubbedTopic, topic)
+        case let .unsubscribeFailure(topics, timeTaken, error):
+            XCTAssertEqual(stubbedTopic, topics[0])
+            XCTAssertEqual(timeTaken, 5)
             let error = error! as NSError
             XCTAssertEqual(error.domain, stubbedError.domain)
             XCTAssertEqual(error.code, stubbedError.code)
@@ -318,20 +317,20 @@ class MulticastCourierEventHandlerTests: XCTestCase {
     }
 
     func testOnMQTTSubscribeAttempt() {
-        sut.onEvent(.init(connectionInfo: nil, event: .subscribeAttempt(topic: stubbedTopic)))
+        sut.onEvent(.init(connectionInfo: nil, event: .subscribeAttempt(topics: [stubbedTopic])))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .subscribeAttempt(topic):
-            XCTAssertEqual(topic, stubbedTopic)
+        case let .subscribeAttempt(topics):
+            XCTAssertEqual(topics[0], stubbedTopic)
         default:
             XCTAssert(false)
         }
     }
 
     func testOnMQTTUnsubscribeAttempt() {
-        sut.onEvent(.init(connectionInfo: nil, event: .unsubscribeAttempt(topic: stubbedTopic)))
+        sut.onEvent(.init(connectionInfo: nil, event: .unsubscribeAttempt(topics: [stubbedTopic])))
         switch mockCourierEventHandler.invokedOnEventParameters?.event.type {
-        case let .unsubscribeAttempt(topic):
-            XCTAssertEqual(topic, stubbedTopic)
+        case let .unsubscribeAttempt(topics):
+            XCTAssertEqual(topics[0], stubbedTopic)
         default:
             XCTAssert(false)
         }

--- a/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
+++ b/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
@@ -94,9 +94,7 @@ class MQTTCourierClientTests: XCTestCase {
     func testConnectWithSuccessCredentials() {
         mockConnectionServiceProvider.stubbedGetConnectOptionsCompletionResult = (.success(stubConnectOptions), ())
         sut.connect()
-        if case let .connectionServiceAuthSuccess(host, port) = self.mockEventHandler.invokedOnEventParameters?.event.type {
-            XCTAssertEqual(host, stubConnectOptions.host)
-            XCTAssertEqual(port, Int(stubConnectOptions.port))
+        if case .connectionServiceAuthSuccess = self.mockEventHandler.invokedOnEventParameters?.event.type {
         } else {
             XCTAssert(false)
         }
@@ -223,20 +221,20 @@ class MQTTCourierClientTests: XCTestCase {
 
     func testOnConnectionSuccess() {
         testPublishConnectionState {
-            sut.onEvent(.init(connectionInfo: nil, event: .connectionSuccess))
+            sut.onEvent(.init(connectionInfo: nil, event: .connectionSuccess(timeTaken: 1)))
             XCTAssertTrue(mockClient.invokedSubscribe)
         }
     }
 
     func testOnConnectionFailure() {
         testPublishConnectionState {
-            sut.onEvent(.init(connectionInfo: nil, event: .connectionFailure(error: nil)))
+            sut.onEvent(.init(connectionInfo: nil, event: .connectionFailure(timeTaken: 1, error: nil)))
         }
     }
 
     func testOnConnectionLost() {
         testPublishConnectionState {
-            sut.onEvent(.init(connectionInfo: nil, event: .connectionLost(error: nil, diffLastInbound: nil, diffLastOutbound: nil)))
+            sut.onEvent(.init(connectionInfo: nil, event: .connectionLost(timeTaken: 1, error: nil, diffLastInbound: nil, diffLastOutbound: nil)))
         }
     }
 

--- a/CourierTests/Core/Mocks/MockMQTTClientFrameworkFactory.swift
+++ b/CourierTests/Core/Mocks/MockMQTTClientFrameworkFactory.swift
@@ -6,8 +6,8 @@ class MockMQTTClientFrameworkFactory: IMQTTClientFrameworkFactory {
 
     var invokedMakeSessionManager = false
     var invokedMakeSessionManagerCount = 0
-    var invokedMakeSessionManagerParameters: (connectRetryTimePolicy: IConnectRetryTimePolicy, persistenceFactory: IMQTTPersistenceFactory, dispatchQueue: DispatchQueue, delegate: MQTTClientFrameworkSessionManagerDelegate, connectTimeoutPolicy: IConnectTimeoutPolicy, idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol)?
-    var invokedMakeSessionManagerParametersList = [(connectRetryTimePolicy: IConnectRetryTimePolicy, persistenceFactory: IMQTTPersistenceFactory, dispatchQueue: DispatchQueue, delegate: MQTTClientFrameworkSessionManagerDelegate, connectTimeoutPolicy: IConnectTimeoutPolicy, idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol)]()
+    var invokedMakeSessionManagerParameters: (connectRetryTimePolicy: IConnectRetryTimePolicy, persistenceFactory: IMQTTPersistenceFactory, dispatchQueue: DispatchQueue, delegate: MQTTClientFrameworkSessionManagerDelegate, connectTimeoutPolicy: IConnectTimeoutPolicy, idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol, eventHandler: ICourierEventHandler)?
+    var invokedMakeSessionManagerParametersList = [(connectRetryTimePolicy: IConnectRetryTimePolicy, persistenceFactory: IMQTTPersistenceFactory, dispatchQueue: DispatchQueue, delegate: MQTTClientFrameworkSessionManagerDelegate, connectTimeoutPolicy: IConnectTimeoutPolicy, idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol, eventHandler: ICourierEventHandler)]()
     var stubbedMakeSessionManagerResult: IMQTTClientFrameworkSessionManager!
 
     func makeSessionManager(
@@ -16,12 +16,13 @@ class MockMQTTClientFrameworkFactory: IMQTTClientFrameworkFactory {
         dispatchQueue: DispatchQueue,
         delegate: MQTTClientFrameworkSessionManagerDelegate,
         connectTimeoutPolicy: IConnectTimeoutPolicy,
-        idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol
+        idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol,
+        eventHandler: ICourierEventHandler
     ) -> IMQTTClientFrameworkSessionManager {
         invokedMakeSessionManager = true
         invokedMakeSessionManagerCount += 1
-        invokedMakeSessionManagerParameters = (connectRetryTimePolicy, persistenceFactory, dispatchQueue, delegate, connectTimeoutPolicy, idleActivityTimeoutPolicy)
-        invokedMakeSessionManagerParametersList.append((connectRetryTimePolicy, persistenceFactory, dispatchQueue, delegate, connectTimeoutPolicy, idleActivityTimeoutPolicy))
+        invokedMakeSessionManagerParameters = (connectRetryTimePolicy, persistenceFactory, dispatchQueue, delegate, connectTimeoutPolicy, idleActivityTimeoutPolicy, eventHandler)
+        invokedMakeSessionManagerParametersList.append((connectRetryTimePolicy, persistenceFactory, dispatchQueue, delegate, connectTimeoutPolicy, idleActivityTimeoutPolicy, eventHandler))
         return stubbedMakeSessionManagerResult
     }
 }

--- a/CourierTests/Core/Mocks/MockMQTTClientFrameworkSessionManager.swift
+++ b/CourierTests/Core/Mocks/MockMQTTClientFrameworkSessionManager.swift
@@ -37,8 +37,8 @@ class MockMQTTClientFrameworkSessionManager: IMQTTClientFrameworkSessionManager 
 
     var invokedConnect = false
     var invokedConnectCount = 0
-    var invokedConnectParameters: (host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, alpn: [String]?, connectHandler: MQTTConnectHandler?)?
-    var invokedConnectParametersList = [(host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, alpn: [String]?, connectHandler: MQTTConnectHandler?)]()
+    var invokedConnectParameters: (host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, alpn: [String]?, connectOptions: ConnectOptions, connectHandler: MQTTConnectHandler?)?
+    var invokedConnectParametersList = [(host: String, port: Int, keepAlive: Int, isCleanSession: Bool, isAuth: Bool, clientId: String, username: String, password: String, lastWill: Bool, lastWillTopic: String?, lastWillMessage: Data?, lastWillQoS: MQTTQosLevel?, lastWillRetainFlag: Bool, securityPolicy: MQTTSSLSecurityPolicy?, certificates: [Any]?, protocolLevel: MQTTProtocolVersion, userProperties: [String: String]?, alpn: [String]?, connectOptions: ConnectOptions, connectHandler: MQTTConnectHandler?)]()
 
     func connect(
         to host: String,
@@ -59,11 +59,12 @@ class MockMQTTClientFrameworkSessionManager: IMQTTClientFrameworkSessionManager 
         protocolLevel: MQTTProtocolVersion,
         userProperties: [String: String]?,
         alpn: [String]?,
+        connectOptions: ConnectOptions,
         connectHandler: MQTTConnectHandler?) {
         invokedConnect = true
         invokedConnectCount += 1
-        invokedConnectParameters = (host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, alpn, connectHandler)
-        invokedConnectParametersList.append((host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, alpn, connectHandler))
+        invokedConnectParameters = (host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, alpn, connectOptions, connectHandler)
+        invokedConnectParametersList.append((host, port, keepAlive, isCleanSession, isAuth, clientId, username, password, lastWill, lastWillTopic, lastWillMessage, lastWillQoS, lastWillRetainFlag, securityPolicy, certificates, protocolLevel, userProperties, alpn, connectOptions, connectHandler))
     }
 
     var invokedDisconnect = false

--- a/CourierTests/Core/Mocks/MockMQTTSession.swift
+++ b/CourierTests/Core/Mocks/MockMQTTSession.swift
@@ -646,12 +646,14 @@ class MockMQTTSession: IMQTTSession {
     var invokedSubscribeParameters: (topics: [String: NSNumber]?, subscribeHandler: MQTTSubscribeHandler?)?
     var invokedSubscribeParametersList = [(topics: [String: NSNumber]?, subscribeHandler: MQTTSubscribeHandler?)]()
     var stubbedSubscribeResult: UInt16! = 0
+    var stubbedSubscribeSubscribeHandlerResult: (NSError?, [NSNumber]?)?
 
     func subscribe(toTopics topics: [String: NSNumber]!, subscribeHandler: MQTTSubscribeHandler!) -> UInt16 {
         invokedSubscribe = true
         invokedSubscribeCount += 1
         invokedSubscribeParameters = (topics, subscribeHandler)
         invokedSubscribeParametersList.append((topics, subscribeHandler))
+        subscribeHandler(stubbedSubscribeSubscribeHandlerResult?.0, stubbedSubscribeSubscribeHandlerResult?.1)
         return stubbedSubscribeResult
     }
 
@@ -660,12 +662,14 @@ class MockMQTTSession: IMQTTSession {
     var invokedUnsubscribeTopicsParameters: (topics: [String]?, unsubscribeHandler: MQTTUnsubscribeHandler?)?
     var invokedUnsubscribeTopicsParametersList = [(topics: [String]?, unsubscribeHandler: MQTTUnsubscribeHandler?)]()
     var stubbedUnsubscribeTopicsResult: UInt16! = 0
+    var stubbedUnsubscribeHandlerResult: NSError?
 
     func unsubscribeTopics(_ topics: [String]!, unsubscribeHandler: MQTTUnsubscribeHandler!) -> UInt16 {
         invokedUnsubscribeTopics = true
         invokedUnsubscribeTopicsCount += 1
         invokedUnsubscribeTopicsParameters = (topics, unsubscribeHandler)
         invokedUnsubscribeTopicsParametersList.append((topics, unsubscribeHandler))
+        unsubscribeHandler(stubbedUnsubscribeHandlerResult)
         return stubbedUnsubscribeTopicsResult
     }
 


### PR DESCRIPTION
This MR adds several missing props in current events (e.g timeTaken for attempt -> (success/failure) types. This timeTaken is in ms and provide a better context on how long the attempt to result operation takes time for analyzing connection health.
