### PR TITLE
Use serial dispatch queue for connect

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -4,5 +4,5 @@ set -eo pipefail
 
 xcodebuild -workspace Courier.xcworkspace \
     -scheme CourierTests \
-    -destination platform=iOS\ Simulator,OS=16.0,name=iPhone\ 13 \
+    -destination platform=iOS\ Simulator,OS=16.2,name=iPhone\ 13 \
     clean test | xcpretty

--- a/CourierMQTT/MQTT/Client/MQTTClient.swift
+++ b/CourierMQTT/MQTT/Client/MQTTClient.swift
@@ -53,8 +53,7 @@ class MQTTClient: IMQTTClient {
             authFailureHandler: configuration.authFailureHandler,
             connectTimeoutPolicy: configuration.connectTimeoutPolicy,
             idleActivityTimeoutPolicy: configuration.idleActivityTimeoutPolicy,
-            isPersistent: configuration.isMQTTPersistentEnabled,
-            shouldInitializeCoreDataPersistenceContext: configuration.shouldInitializeCoreDataPersistenceContext
+            isPersistent: configuration.isMQTTPersistentEnabled
         )
 
         connection = mqttConnectionFactory.makeConnection(connectionConfig: connectionConfig)

--- a/CourierMQTT/MQTT/Configuration/IMQTTConfiguration.swift
+++ b/CourierMQTT/MQTT/Configuration/IMQTTConfiguration.swift
@@ -12,5 +12,4 @@ protocol IMQTTConfiguration {
     var messageCleanupInterval: TimeInterval { get }
     
     var isMQTTPersistentEnabled: Bool { get }
-    var shouldInitializeCoreDataPersistenceContext: Bool { get }
 }

--- a/CourierMQTT/MQTT/Configuration/MQTTConfiguration.swift
+++ b/CourierMQTT/MQTT/Configuration/MQTTConfiguration.swift
@@ -10,7 +10,6 @@ struct MQTTConfiguration: IMQTTConfiguration {
     var messagePersistenceTTLSeconds: TimeInterval
     var messageCleanupInterval: TimeInterval
     var isMQTTPersistentEnabled: Bool
-    var shouldInitializeCoreDataPersistenceContext: Bool
 
     init(connectRetryTimePolicy: IConnectRetryTimePolicy = ConnectRetryTimePolicy(),
          connectTimeoutPolicy: IConnectTimeoutPolicy = ConnectTimeoutPolicy(),
@@ -19,8 +18,7 @@ struct MQTTConfiguration: IMQTTConfiguration {
          eventHandler: ICourierEventHandler,
          messagePersistenceTTLSeconds: TimeInterval = 0,
          messageCleanupInterval: TimeInterval = 10,
-         isMQTTPersistentEnabled: Bool,
-         shouldInitializeCoreDataPersistenceContext: Bool) {
+         isMQTTPersistentEnabled: Bool) {
         self.connectRetryTimePolicy = connectRetryTimePolicy
         self.connectTimeoutPolicy = connectTimeoutPolicy
         self.idleActivityTimeoutPolicy = idleActivityTimeoutPolicy
@@ -29,6 +27,5 @@ struct MQTTConfiguration: IMQTTConfiguration {
         self.messagePersistenceTTLSeconds = messagePersistenceTTLSeconds
         self.messageCleanupInterval = messageCleanupInterval
         self.isMQTTPersistentEnabled = isMQTTPersistentEnabled
-        self.shouldInitializeCoreDataPersistenceContext = shouldInitializeCoreDataPersistenceContext
     }
 }

--- a/CourierMQTT/MQTT/Connection/Factory/IMQTTConnectionFactory.swift
+++ b/CourierMQTT/MQTT/Connection/Factory/IMQTTConnectionFactory.swift
@@ -13,8 +13,7 @@ struct MQTTClientFrameworkConnectionFactory: IMQTTConnectionFactory {
         MQTTClientFrameworkConnection(connectionConfig: connectionConfig,
                                       clientFactory: clientFactory,
                                       persistenceFactory: MQTTPersistenceFactory(
-                                        isPersistent: connectionConfig.isPersistent,
-                                        shouldInitializeCoreDataPersistenceContext: connectionConfig.shouldInitializeCoreDataPersistenceContext))
+                                        isPersistent: connectionConfig.isPersistent))
     }
 
 }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTPersistence.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/IMQTTPersistence.swift
@@ -8,15 +8,13 @@ protocol IMQTTPersistenceFactory {
 struct MQTTPersistenceFactory: IMQTTPersistenceFactory {
 
     let isPersistent: Bool
-    let shouldInitializeCoreDataPersistenceContext: Bool
 
     private let maxWindowSize: Int = 16
     private let maxMessages: Int = 5000
     private let maxSize: Int = 128 * 1024 * 1024
     
-    init(isPersistent: Bool = false, shouldInitializeCoreDataPersistenceContext: Bool = true) {
+    init(isPersistent: Bool = false) {
         self.isPersistent = isPersistent
-        self.shouldInitializeCoreDataPersistenceContext = shouldInitializeCoreDataPersistenceContext
     }
     
     func makePersistence() -> MQTTPersistence {

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -114,12 +114,6 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         self.eventHandler = eventHandler
         
         super.init()
-        if let coreDataPersistence = persistence as? MQTTCoreDataPersistence,
-           let persistenceFactory = mqttPersistenceFactory as? MQTTPersistenceFactory,
-           persistenceFactory.shouldInitializeCoreDataPersistenceContext {
-            queue.async { coreDataPersistence.initializeManagedObjectContext() }
-        }
-
         self.updateState(to: .starting)
         self.reconnectTimer = ReconnectTimer(retryInterval: retryInterval, maxRetryInterval: maxRetryInterval, queue: queue, reconnect: { [weak self] in
             self?.reconnect()

--- a/CourierMQTT/MQTT/Models/ConnectionConfig.swift
+++ b/CourierMQTT/MQTT/Models/ConnectionConfig.swift
@@ -9,5 +9,4 @@ struct ConnectionConfig {
     var idleActivityTimeoutPolicy: IdleActivityTimeoutPolicyProtocol
     
     var isPersistent: Bool
-    var shouldInitializeCoreDataPersistenceContext: Bool
 }

--- a/CourierTests/Core/MQTT/Client/MQTTClientTests.swift
+++ b/CourierTests/Core/MQTT/Client/MQTTClientTests.swift
@@ -292,7 +292,7 @@ extension MQTTClientTests {
 
     var stubbedConfiguration: IMQTTConfiguration {
         MQTTConfiguration(
-            connectRetryTimePolicy: mockConnectRetryTimePolicy, authFailureHandler: mockAuthFailureHandler, eventHandler: mockEventHandler, isMQTTPersistentEnabled: true, shouldInitializeCoreDataPersistenceContext: true)
+            connectRetryTimePolicy: mockConnectRetryTimePolicy, authFailureHandler: mockAuthFailureHandler, eventHandler: mockEventHandler, isMQTTPersistentEnabled: true)
     }
 
     var stubConnectOptions: ConnectOptions {

--- a/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
+++ b/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
@@ -40,8 +40,7 @@ class MQTTClientFrameworkConnectionTests: XCTestCase {
                 authFailureHandler: mockAuthFailureHandler,
                 connectTimeoutPolicy: mockConnectTimeoutPolicy,
                 idleActivityTimeoutPolicy: IdleActivityTimeoutPolicy(),
-                isPersistent: true,
-                shouldInitializeCoreDataPersistenceContext: true
+                isPersistent: true
             ),
             clientFactory: mockClientFactory,
             persistenceFactory: mockPersistenceFactory

--- a/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
+++ b/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
@@ -94,29 +94,44 @@ class MQTTCourierClientTests: XCTestCase {
     func testConnectWithSuccessCredentials() {
         mockConnectionServiceProvider.stubbedGetConnectOptionsCompletionResult = (.success(stubConnectOptions), ())
         sut.connect()
-        if case .connectionServiceAuthSuccess = self.mockEventHandler.invokedOnEventParameters?.event.type {
-        } else {
-            XCTAssert(false)
+        let expectation_ = expectation(description: "test")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            expectation_.fulfill()
         }
-        XCTAssertTrue(mockAuthRetryPolicy.invokedResetParams)
-        XCTAssertTrue(mockClient.invokedReset)
-        XCTAssertTrue(mockClient.invokedConnect)
-
-        XCTAssertEqual(mockClient.invokedConnectParameters?.connectOptions.host, stubConnectOptions.host)
-
-        XCTAssertEqual(mockClient.invokedConnectParameters?.connectOptions.port, UInt16(stubConnectOptions.port))
-        XCTAssertEqual(mockClient.invokedConnectParameters?.connectOptions.keepAlive, UInt16(pingInterval))
-        XCTAssertEqual(mockClient.invokedConnectParameters?.connectOptions.clientId, stubConnectOptions.clientId)
-        XCTAssertEqual(mockClient.invokedConnectParameters?.connectOptions.username, stubConnectOptions.username)
-        XCTAssertEqual(mockClient.invokedConnectParameters?.connectOptions.password, stubConnectOptions.password)
+        waitForExpectations(timeout: 0.1) { _ in
+            if case .connectionServiceAuthSuccess = self.mockEventHandler.invokedOnEventParameters?.event.type {
+            } else {
+                XCTAssert(false)
+            }
+            XCTAssertTrue(self.mockAuthRetryPolicy.invokedResetParams)
+            XCTAssertTrue(self.mockClient.invokedReset)
+            XCTAssertTrue(self.mockClient.invokedConnect)
+            
+            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.host, self.stubConnectOptions.host)
+            
+            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.port, UInt16(self.stubConnectOptions.port))
+            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.keepAlive, UInt16(self.pingInterval))
+            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.clientId, self.stubConnectOptions.clientId)
+            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.username, self.stubConnectOptions.username)
+            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.password, self.stubConnectOptions.password)
+            
+        }
     }
+        
+        
+     
 
     func testConnectWithFailureCredentials() {
         mockConnectionServiceProvider.stubbedGetConnectOptionsCompletionResult = (.failure(stubbedError), ())
         mockAuthRetryPolicy.stubbedGetRetryTimeResult = 0.1
 
         sut.connect()
-        if case .connectionServiceAuthFailure = self.mockEventHandler.invokedOnEventParametersList[1]?.event.type {
+        let expectation_ = expectation(description: "test")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            expectation_.fulfill()
+        }
+        waitForExpectations(timeout: 0.1) { _ in
+            if case .connectionServiceAuthFailure = self.mockEventHandler.invokedOnEventParametersList[1]?.event.type {
             XCTAssert(true)
         } else {
             XCTAssert(false)
@@ -127,7 +142,9 @@ class MQTTCourierClientTests: XCTestCase {
         } else {
             XCTAssert(false)
         }
-        XCTAssertTrue(mockAuthRetryPolicy.invokedShouldRetry)
+            XCTAssertTrue(self.mockAuthRetryPolicy.invokedShouldRetry)
+        }
+      
     }
 
     func testSubscribeTopics() {


### PR DESCRIPTION
- Remove workaround for initialize managed object context to handle "nil is not a legal persistent store coordinator for MQTTFLow" This is mostly caused by concurrency issue. One thread is initializing the persistent store and other is accessing it.
- Make sure to run connect async in serial queue to avoid this issue