### PR TITLE
Add new functionality for QoS 1 without persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 # Created by https://www.toptal.com/developers/gitignore/api/macos,fastlane,xcode,cocoapods,carthage,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,fastlane,xcode,cocoapods,carthage,visualstudiocode
 
-### SwiftPM ###
-
+### SPM ###
 .build/
 .swiftpm/
 Package.resolved

--- a/CourierCore/Models/QoS.swift
+++ b/CourierCore/Models/QoS.swift
@@ -13,11 +13,14 @@ public enum QoS: Int {
     
     /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
        nor persisted and neither retied at send after one attempt.
-       The message arrives at the receiver either once or not at all **/
+       The message arrives at the receiver either once or not at all.
+        Your broker need to be configured to support this **/
     case oneWithoutPersistenceAndNoRetry = 3
     
     /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
-         not persisted. The messages are retried within active connection if delivery is not acknowledged.**/
+       nor persisted and neither retied at send after one attempt.
+       The message arrives at the receiver either once or not at all.
+        Your broker need to be configured to support this **/
     case oneWithoutPersistenceAndRetry = 4
     
     // Used internally by the Courier for determinining publish persistence and subscribe payload behaviors

--- a/CourierCore/Models/QoS.swift
+++ b/CourierCore/Models/QoS.swift
@@ -23,14 +23,29 @@ public enum QoS: Int {
         Your broker need to be configured to support this **/
     case oneWithoutPersistenceAndRetry = 4
     
-    // Used internally by the Courier for determinining publish persistence and subscribe payload behaviors
-    var internalRawValue: (value: Int, type: Int) {
+    public var rawValue: Int {
         switch self {
-        case .zero: return (QoS.zero.rawValue, self.rawValue)
-        case .one: return (QoS.one.rawValue, self.rawValue)
-        case .two: return (QoS.one.rawValue, self.rawValue)
-        case .oneWithoutPersistenceAndNoRetry: return (QoS.zero.rawValue, self.rawValue)
-        case .oneWithoutPersistenceAndRetry: return (QoS.zero.rawValue, self.rawValue)
+        case .zero:
+            return 0
+        case .one, .oneWithoutPersistenceAndNoRetry, .oneWithoutPersistenceAndRetry:
+            return 1
+        case .two:
+            return 2
+        }
+    }
+    
+    public var type: Int {
+        switch self {
+        case .zero:
+            return 0
+        case .one:
+            return 1
+        case .two:
+            return 2
+        case .oneWithoutPersistenceAndNoRetry:
+            return 3
+        case .oneWithoutPersistenceAndRetry:
+            return 4
         }
     }
 }

--- a/CourierCore/Models/QoS.swift
+++ b/CourierCore/Models/QoS.swift
@@ -1,10 +1,33 @@
 import Foundation
 
 public enum QoS: Int {
-
+    
+    // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718100
     case zero = 0
-
+    
+    // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718100
     case one = 1
-
+    
+    // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718100
     case two = 2
+    
+    /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
+       nor persisted and neither retied at send after one attempt.
+       The message arrives at the receiver either once or not at all **/
+    case oneWithoutPersistenceAndNoRetry = 3
+    
+    /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
+         not persisted. The messages are retried within active connection if delivery is not acknowledged.**/
+    case oneWithoutPersistenceAndRetry = 4
+    
+    // Used internally by the Courier for determinining publish persistence and subscribe payload behaviors
+    var internalRawValue: (value: Int, type: Int) {
+        switch self {
+        case .zero: return (QoS.zero.rawValue, self.rawValue)
+        case .one: return (QoS.one.rawValue, self.rawValue)
+        case .two: return (QoS.one.rawValue, self.rawValue)
+        case .oneWithoutPersistenceAndNoRetry: return (QoS.zero.rawValue, self.rawValue)
+        case .oneWithoutPersistenceAndRetry: return (QoS.zero.rawValue, self.rawValue)
+        }
+    }
 }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -297,7 +297,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         topics.forEach { topic, qos in
             let attemptTimestamp = Date()
             self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeAttempt(topics: [topic])))
-            session?.subscribe(toTopics: [topic: NSNumber(value: qos.rawValue)], subscribeHandler: { [weak self] (error, responseCodes) in
+            session?.subscribe(toTopics: [topic: NSNumber(value: qos.type)], subscribeHandler: { [weak self] (error, responseCodes) in
                 guard let self = self else { return }
                 if let error = error {
                     self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeFailure(topics: [(topic, qos)], timeTaken: attemptTimestamp.timeTaken, error: error)))

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrramework+Extension.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrramework+Extension.swift
@@ -41,6 +41,6 @@ extension MQTTCommandType {
 
 extension MQTTQosLevel {
     init(qos: QoS) {
-        self = MQTTQosLevel(rawValue: UInt8(qos.rawValue)) ?? .atMostOnce
+        self = MQTTQosLevel(rawValue: UInt8(qos.type)) ?? .atMostOnce
     }
 }

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.h
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.h
@@ -12,7 +12,18 @@
 typedef NS_ENUM(UInt8, MQTTQosLevel) {
     MQTTQosLevelAtMostOnce = 0,
     MQTTQosLevelAtLeastOnce = 1,
-    MQTTQosLevelExactlyOnce = 2
+    MQTTQosLevelExactlyOnce = 2,
+    
+    /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
+       nor persisted and neither retied at send after one attempt.
+       The message arrives at the receiver either once or not at all.
+        Your broker need to be configured to support this **/
+    MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry = 3,
+    
+    /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
+         not persisted. The messages are retried within active connection if delivery is not acknowledged.
+        Your broker need to be configured to support this **/
+    MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry = 4
 };
 
 /**

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
@@ -230,8 +230,8 @@
         [data appendMQTTString:topic];
         int qos = [topics[topic] intValue];
         
-        bool bitOr0x4 = false;
-        bool bitOr0x8 = false;
+        bool bitOr0x4;
+        bool bitOr0x8;
         if (qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry) {
             bitOr0x4 = false;
             bitOr0x8 = false;

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
@@ -228,7 +228,7 @@
 
     for (NSString *topic in topics.allKeys) {
         [data appendMQTTString:topic];
-        UInt8 qos = [topics[topic] intValue];
+        Byte qos = [topics[topic] intValue];
         
         bool bitOr0x4;
         bool bitOr0x8;
@@ -245,7 +245,7 @@
             bitOr0x8 = true;
         }
         
-        UInt8 nextByte = 0 | qos;
+        Byte nextByte = 0 | qos;
         if (!bitOr0x4) {
             nextByte |= 0x4;
         }

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
@@ -228,14 +228,16 @@
 
     for (NSString *topic in topics.allKeys) {
         [data appendMQTTString:topic];
-        int qos = [topics[topic] intValue];
+        UInt8 qos = [topics[topic] intValue];
         
         bool bitOr0x4;
         bool bitOr0x8;
         if (qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry) {
+            qos = MQTTQosLevelAtLeastOnce;
             bitOr0x4 = false;
             bitOr0x8 = false;
         } else if (qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry) {
+            qos = MQTTQosLevelAtLeastOnce;
             bitOr0x4 = false;
             bitOr0x8 = true;
         } else {

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
@@ -228,7 +228,29 @@
 
     for (NSString *topic in topics.allKeys) {
         [data appendMQTTString:topic];
-        [data appendByte:[topics[topic] intValue]];
+        int qos = [topics[topic] intValue];
+        
+        bool bitOr0x4 = false;
+        bool bitOr0x8 = false;
+        if (qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry) {
+            bitOr0x4 = false;
+            bitOr0x8 = false;
+        } else if (qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry) {
+            bitOr0x4 = false;
+            bitOr0x8 = true;
+        } else {
+            bitOr0x4 = true;
+            bitOr0x8 = true;
+        }
+        
+        UInt8 nextByte = 0 | qos;
+        if (bitOr0x4) {
+            nextByte |= 0x04;
+        }
+        
+        if (bitOr0x4) {
+            nextByte |= 0x08;
+        }
     }
     MQTTMessage* msg = [[MQTTMessage alloc] initWithType:MQTTSubscribe
                                                      qos:1

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
@@ -247,10 +247,10 @@
         
         UInt8 nextByte = 0 | qos;
         if (!bitOr0x4) {
-            nextByte |= 0x04;
+            nextByte |= 0x4;
         }
         if (!bitOr0x8) {
-            nextByte |= 0x08;
+            nextByte |= 0x8;
         }
         [data appendByte:nextByte];
     }

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.m
@@ -244,13 +244,13 @@
         }
         
         UInt8 nextByte = 0 | qos;
-        if (bitOr0x4) {
+        if (!bitOr0x4) {
             nextByte |= 0x04;
         }
-        
-        if (bitOr0x4) {
+        if (!bitOr0x8) {
             nextByte |= 0x08;
         }
+        [data appendByte:nextByte];
     }
     MQTTMessage* msg = [[MQTTMessage alloc] initWithType:MQTTSubscribe
                                                      qos:1
@@ -509,7 +509,6 @@
 - (NSData *)wireFormat {
     NSMutableData *buffer = [[NSMutableData alloc] init];
 
-      
     UInt8 header;
     header = (self.type & 0x0f) << 4;
     if (self.dupFlag) {

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTSession.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTSession.m
@@ -378,16 +378,28 @@ NSString * const MQTTClientcourier = @"GJ";
     if (MQTTStrict.strict &&
         qos != MQTTQosLevelAtMostOnce &&
         qos != MQTTQosLevelAtLeastOnce &&
-        qos != MQTTQosLevelExactlyOnce) {
+        qos != MQTTQosLevelExactlyOnce &&
+        qos != MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry &&
+        qos != MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry
+        ) {
         NSException* myException = [NSException
                                     exceptionWithName:@"Illegal QoS level"
-                                    reason:[NSString stringWithFormat:@"%d is not 0, 1, or 2", qos]
+                                    reason:[NSString stringWithFormat:@"%d is not 0, 1, 2, 3, or 4", qos]
                                     userInfo:nil];
         @throw myException;
     }
 
     UInt16 msgId = 0;
-    if (!qos) {
+    if (!qos ||
+        qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry ||
+        qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry
+    ) {
+        // Set these *special QoSes* as QoS One
+        if (qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry || qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry) {
+            qos = MQTTQosLevelAtLeastOnce;
+            // TODO: Confirm MsgID
+//            msgId = [self nextMsgId];
+        }
         MQTTMessage *msg = [MQTTMessage publishMessageWithData:data
                                                        onTopic:topic
                                                            qos:qos

--- a/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTSession.m
+++ b/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTSession.m
@@ -251,10 +251,13 @@ NSString * const MQTTClientcourier = @"GJ";
         if (MQTTStrict.strict &&
             qos.intValue != MQTTQosLevelAtMostOnce &&
             qos.intValue != MQTTQosLevelAtLeastOnce &&
-            qos.intValue != MQTTQosLevelExactlyOnce) {
+            qos.intValue != MQTTQosLevelExactlyOnce &&
+            qos.intValue != MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry &&
+            qos.intValue != MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry
+        ) {
             NSException* myException = [NSException
                                         exceptionWithName:@"Illegal QoS level"
-                                        reason:[NSString stringWithFormat:@"%d is not 0, 1, or 2", qos.intValue]
+                                        reason:[NSString stringWithFormat:@"%d is not 0, 1, 2, 3, or 4", qos.intValue]
                                         userInfo:nil];
             @throw myException;
         }
@@ -397,8 +400,7 @@ NSString * const MQTTClientcourier = @"GJ";
         // Set these *special QoSes* as QoS One
         if (qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry || qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry) {
             qos = MQTTQosLevelAtLeastOnce;
-            // TODO: Confirm MsgID
-//            msgId = [self nextMsgId];
+            msgId = [self nextMsgId];
         }
         MQTTMessage *msg = [MQTTMessage publishMessageWithData:data
                                                        onTopic:topic
@@ -1412,7 +1414,10 @@ NSString * const MQTTClientcourier = @"GJ";
     if (self.shouldEnableActivityCheckTimeout) {
         switch (message.type) {
             case MQTTPublish:
-                if (message.qos == MQTTQosLevelAtMostOnce) return;
+                if (message.qos == MQTTQosLevelAtMostOnce ||
+                    message.qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry ||
+                    message.qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry
+                ) return;
                 [self checkAndSetFastReconnectTimestamp];
                 return;
             

--- a/docs/docs/Message QoS.md
+++ b/docs/docs/Message QoS.md
@@ -7,4 +7,14 @@ When you talk about QoS in MQTT, you need to consider the two sides of message d
 - Message delivery form the publishing client to the broker.
 - Message delivery from the broker to the subscribing client.
 
-You can read more about the detail of QoS in MQTT from [HiveMQ](https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/) site.
+You can read more about the detail of QoS in MQTT from [HiveMQ site](https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/).
+
+:warning: **
+These are non standard QoS options. You need to have compatible broker to use these QoS options
+
+We added two more Qos options
+
+- QoS1 with no persistence and no retry: Like QoS1, Message delivery is acknowledged with PubAck, but unlike Qos1 messages, these are
+  neither persisted and nor retried at send after single attempt. The message arrives at the receiver either once or not at all
+- QoS1 with no persistence and with retry: Like QoS1, Message delivery is acknowledged with PubAck, but unlike Qos1 messages, these are
+  not persisted. The messages are retried within current session if delivery is not acknowledged


### PR DESCRIPTION
We added two more Qos options:

- QoS1 with no persistence and no retry: Like QoS1, Message delivery is acknowledged with PubAck, but unlike Qos1 messages, these are neither persisted and nor retried at send after single attempt. The message arrives at the receiver either once or not at all

- QoS1 with no persistence and with retry: Like QoS1, Message delivery is acknowledged with PubAck, but unlike Qos1 messages, these are not persisted. The messages are retried within current session if delivery is not acknowledged

:warning: **

These are non standard QoS options. You need to have compatible broker to use these QoS options
- When subscribing with special QoSes, byte flag(s) will be added to the payload
- When publishing with special QoSes, QoS will be sent as 1 to the broker but with no persistence on client side.

