### PR TITLE
[Chore] - Allow secured connection by scheme param

### DIFF
--- a/CourierCore/Models/ConnectOptions.swift
+++ b/CourierCore/Models/ConnectOptions.swift
@@ -22,8 +22,6 @@ public struct ConnectOptions: Equatable {
     
     public let scheme: String?
 
-    public let useSSLWithTLS: Bool
-
     public init(
         host: String,
         port: UInt16,
@@ -34,8 +32,7 @@ public struct ConnectOptions: Equatable {
         isCleanSession: Bool = false,
         userProperties: [String: String]? = nil,
         alpn: [String]? = nil,
-        scheme: String? = nil,
-        useSSLWithTLS: Bool = false
+        scheme: String? = nil
     ) {
         self.host = host
         self.port = port
@@ -47,6 +44,5 @@ public struct ConnectOptions: Equatable {
         self.userProperties = userProperties
         self.alpn = alpn
         self.scheme = scheme
-        self.useSSLWithTLS = useSSLWithTLS
     }
 }

--- a/CourierCore/Models/ConnectOptions.swift
+++ b/CourierCore/Models/ConnectOptions.swift
@@ -22,6 +22,8 @@ public struct ConnectOptions: Equatable {
     
     public let scheme: String?
 
+    public let useSSLWithTLS: Bool
+
     public init(
         host: String,
         port: UInt16,
@@ -32,7 +34,8 @@ public struct ConnectOptions: Equatable {
         isCleanSession: Bool = false,
         userProperties: [String: String]? = nil,
         alpn: [String]? = nil,
-        scheme: String? = nil
+        scheme: String? = nil,
+        useSSLWithTLS: Bool = false
     ) {
         self.host = host
         self.port = port
@@ -43,6 +46,7 @@ public struct ConnectOptions: Equatable {
         self.isCleanSession = isCleanSession
         self.userProperties = userProperties
         self.alpn = alpn
-        self.scheme = scheme
+        self.scheme = scheme,
+        self.useSSLWithTLS: Bool = false
     }
 }

--- a/CourierCore/Models/ConnectOptions.swift
+++ b/CourierCore/Models/ConnectOptions.swift
@@ -19,6 +19,8 @@ public struct ConnectOptions: Equatable {
     public let userProperties: [String: String]?
     
     public let alpn: [String]?
+    
+    public let scheme: String?
 
     public init(
         host: String,
@@ -29,7 +31,8 @@ public struct ConnectOptions: Equatable {
         password: String,
         isCleanSession: Bool = false,
         userProperties: [String: String]? = nil,
-        alpn: [String]? = nil
+        alpn: [String]? = nil,
+        scheme: String? = nil
     ) {
         self.host = host
         self.port = port
@@ -40,5 +43,6 @@ public struct ConnectOptions: Equatable {
         self.isCleanSession = isCleanSession
         self.userProperties = userProperties
         self.alpn = alpn
+        self.scheme = scheme
     }
 }

--- a/CourierCore/Models/ConnectOptions.swift
+++ b/CourierCore/Models/ConnectOptions.swift
@@ -46,7 +46,7 @@ public struct ConnectOptions: Equatable {
         self.isCleanSession = isCleanSession
         self.userProperties = userProperties
         self.alpn = alpn
-        self.scheme = scheme,
-        self.useSSLWithTLS: Bool = false
+        self.scheme = scheme
+        self.useSSLWithTLS = useSSLWithTLS
     }
 }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -75,15 +75,18 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
         let isTls = false
         var securityPolicy: MQTTSSLSecurityPolicy?
         
+        if port == 443 {
+            securityPolicy = MQTTSSLSecurityPolicy()
+            securityPolicy?.allowInvalidCertificates = true
+        }
+        
         switch connectOptions.scheme {
             case "tls":
                 securityPolicy = MQTTSSLSecurityPolicy()
                 securityPolicy?.allowInvalidCertificates = true
-                isTls = true
             case "ssl":
                 securityPolicy = MQTTSSLSecurityPolicy()
                 securityPolicy?.allowInvalidCertificates = true
-            isTls = true
             default:
                 break
         }
@@ -108,8 +111,7 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
             userProperties: connectOptions.userProperties,
             alpn: connectOptions.alpn,
             connectOptions: connectOptions,
-            connectHandler: nil,
-            isTls: isTls
+            connectHandler: nil
         )
     }
 

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -72,23 +72,11 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
         self.connectOptions = connectOptions
 
         let port = Int(connectOptions.port)
-        let isTls = false
         var securityPolicy: MQTTSSLSecurityPolicy?
         
-        if port == 443 {
+        if scheme == "ssl" || scheme == "tls" {
             securityPolicy = MQTTSSLSecurityPolicy()
             securityPolicy?.allowInvalidCertificates = true
-        }
-        
-        switch connectOptions.scheme {
-            case "tls":
-                securityPolicy = MQTTSSLSecurityPolicy()
-                securityPolicy?.allowInvalidCertificates = true
-            case "ssl":
-                securityPolicy = MQTTSSLSecurityPolicy()
-                securityPolicy?.allowInvalidCertificates = true
-            default:
-                break
         }
 
         sessionManager.connect(

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -74,7 +74,7 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
         let port = Int(connectOptions.port)
         var securityPolicy: MQTTSSLSecurityPolicy?
         
-        if scheme == "ssl" || scheme == "tls" {
+        if scheme == "ssl" || scheme == "tls" || useSSLWithTLS {
             securityPolicy = MQTTSSLSecurityPolicy()
             securityPolicy?.allowInvalidCertificates = true
         }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -74,7 +74,7 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
         let port = Int(connectOptions.port)
         var securityPolicy: MQTTSSLSecurityPolicy?
         
-        if scheme == "ssl" || scheme == "tls" || useSSLWithTLS {
+        if connectOptions.scheme == "ssl" || connectOptions.scheme == "tls" {
             securityPolicy = MQTTSSLSecurityPolicy()
             securityPolicy?.allowInvalidCertificates = true
         }

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -72,10 +72,20 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
         self.connectOptions = connectOptions
 
         let port = Int(connectOptions.port)
+        let isTls = false
         var securityPolicy: MQTTSSLSecurityPolicy?
-        if port == 443 {
-            securityPolicy = MQTTSSLSecurityPolicy()
-            securityPolicy?.allowInvalidCertificates = true
+        
+        switch connectOptions.scheme {
+            case "tls":
+                securityPolicy = MQTTSSLSecurityPolicy()
+                securityPolicy?.allowInvalidCertificates = true
+                isTls = true
+            case "ssl":
+                securityPolicy = MQTTSSLSecurityPolicy()
+                securityPolicy?.allowInvalidCertificates = true
+            isTls = true
+            default:
+                break
         }
 
         sessionManager.connect(
@@ -98,7 +108,8 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
             userProperties: connectOptions.userProperties,
             alpn: connectOptions.alpn,
             connectOptions: connectOptions,
-            connectHandler: nil
+            connectHandler: nil,
+            isTls: isTls
         )
     }
 

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -144,7 +144,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         printDebug("MQTT - COURIER: Client Session Manager connect to: \(host)")
         self.connectOptions = connectOptions
         let shouldReconnect = self.session != nil
-        let isTls = port == 443
+        let isTls = port == 443 || securityPolicy != nil
 
         if (self.session == nil || host != self.host) ||
             port != self.port ?? 0 ||

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -144,7 +144,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         printDebug("MQTT - COURIER: Client Session Manager connect to: \(host)")
         self.connectOptions = connectOptions
         let shouldReconnect = self.session != nil
-        let isTls = port == 443 || securityPolicy != nil
+        let isTls = connectOptions.scheme == "ssl" || connectOptions.scheme == "tls" || connectOptions.useSSLWithTLS
 
         if (self.session == nil || host != self.host) ||
             port != self.port ?? 0 ||

--- a/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -144,7 +144,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         printDebug("MQTT - COURIER: Client Session Manager connect to: \(host)")
         self.connectOptions = connectOptions
         let shouldReconnect = self.session != nil
-        let isTls = connectOptions.scheme == "ssl" || connectOptions.scheme == "tls" || connectOptions.useSSLWithTLS
+        let isTls = connectOptions.scheme == "ssl" || connectOptions.scheme == "tls"
 
         if (self.session == nil || host != self.host) ||
             port != self.port ?? 0 ||

--- a/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
+++ b/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
@@ -346,7 +346,8 @@ extension MQTTClientFrameworkConnectionTests {
             clientId: "1234",
             username: "hello",
             password: "word",
-            isCleanSession: true
+            isCleanSession: true,
+            scheme: "tls",
         )
     }
     

--- a/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
+++ b/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
@@ -347,7 +347,7 @@ extension MQTTClientFrameworkConnectionTests {
             username: "hello",
             password: "word",
             isCleanSession: true,
-            scheme: "tls",
+            scheme: "tls"
         )
     }
     

--- a/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkSessionManagerTests.swift
+++ b/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkSessionManagerTests.swift
@@ -264,7 +264,7 @@ extension MQTTClientFrameworkSessionManagerTests {
     }
     
     var stubConnectOptions: ConnectOptions {
-        ConnectOptions(host: "host", port: 443, keepAlive: 240, clientId: "clientid", username: "username", password: "password", isCleanSession: true, userProperties: nil, alpn: nil)
+        ConnectOptions(host: "host", port: 443, keepAlive: 240, clientId: "clientid", username: "username", password: "password", isCleanSession: true, userProperties: nil, alpn: nil, scheme: "tls")
     }
     
     var stubbedError: NSError {

--- a/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
+++ b/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
@@ -358,7 +358,7 @@ extension MQTTCourierClientTests {
             clientId: "xyz",
             username: "abc",
             password: "token",
-            isCleanSession: true,
+            isCleanSession: true
         )
     }
     

--- a/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
+++ b/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
@@ -358,7 +358,7 @@ extension MQTTCourierClientTests {
             clientId: "xyz",
             username: "abc",
             password: "token",
-            isCleanSession: true
+            isCleanSession: true,
         )
     }
     


### PR DESCRIPTION
Hi, I just try to make an improvement in the connection option so that the user can use a secured connection without being limited by the port connection. I added the 'scheme' param which is used too in Courier Android so that can have the same name convention. In Courier Flutter, it has already added the 'scheme' param but when it passes to iOS method channels, the param 'scheme' is not used. I have tested it on my project case and it solved my connection problem.