### PR TITLE
Add ConnectionInfo to MQTTChuck & UI Improvement

### DIFF
--- a/Courier.xcodeproj/project.pbxproj
+++ b/Courier.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		B00C824E285B152000B2BDBA /* MesssageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00C8246285B152000B2BDBA /* MesssageData.swift */; };
 		B00C824F285B152000B2BDBA /* SubscribeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00C8247285B152000B2BDBA /* SubscribeData.swift */; };
 		B00C842C285C3CA000B2BDBA /* PrintDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00C842B285C3CA000B2BDBA /* PrintDebug.swift */; };
+		B0C3CDB92A6E21DA00A87579 /* libCourierMQTTChuck.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B0EF8E2929E40861001DF51B /* libCourierMQTTChuck.a */; };
 		B0DA90B92856F5E300F6512D /* CourierE2EApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DA90B82856F5E300F6512D /* CourierE2EApp.swift */; };
 		B0DA90BD2856F5E400F6512D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B0DA90BC2856F5E400F6512D /* Assets.xcassets */; };
 		B0DA90C02856F5E400F6512D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B0DA90BF2856F5E400F6512D /* Preview Assets.xcassets */; };
@@ -276,6 +277,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		B0C3CDBA2A6E21DA00A87579 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B0669632623E4D800129BAB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B0EF8E2829E40861001DF51B;
+			remoteInfo = CourierMQTTChuck;
+		};
 		B0DA90E4285739A000F6512D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8B0669632623E4D800129BAB /* Project object */;
@@ -731,6 +739,7 @@
 				B0DA90E3285739A000F6512D /* libCourierCore.a in Frameworks */,
 				B0DA90E6285739A000F6512D /* libCourierMQTT.a in Frameworks */,
 				B0DA90EC285739A000F6512D /* libMQTTClientGJ.a in Frameworks */,
+				B0C3CDB92A6E21DA00A87579 /* libCourierMQTTChuck.a in Frameworks */,
 				2F2A9AD27BFADBC670DC91E7 /* Pods_CourierE2EApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1754,6 +1763,7 @@
 				B0DA90E8285739A000F6512D /* PBXTargetDependency */,
 				B0DA90EB285739A000F6512D /* PBXTargetDependency */,
 				B0DA90EE285739A000F6512D /* PBXTargetDependency */,
+				B0C3CDBB2A6E21DA00A87579 /* PBXTargetDependency */,
 			);
 			name = CourierE2EApp;
 			productName = CourierE2EApp;
@@ -2256,6 +2266,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		B0C3CDBB2A6E21DA00A87579 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B0EF8E2829E40861001DF51B /* CourierMQTTChuck */;
+			targetProxy = B0C3CDBA2A6E21DA00A87579 /* PBXContainerItemProxy */;
+		};
 		B0DA90E5285739A000F6512D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 8BE0DD40270BE3B000630D60 /* CourierCore */;

--- a/CourierE2EApp/View Models/ConnectionObservableObject.swift
+++ b/CourierE2EApp/View Models/ConnectionObservableObject.swift
@@ -163,7 +163,7 @@ final class ConnectionObservableObject: ObservableObject {
 extension ConnectionObservableObject: ICourierEventHandler {
     
     func onEvent(_ event: CourierEvent) {
-        print("EVENT: \(event.type)")
+//        print("EVENT: \(event.type)")
         switch event.type {
         case .connectionSuccess:
             if connectionServiceProvider.isCleanSession {

--- a/CourierMQTTChuck/MQTTChuckLog.swift
+++ b/CourierMQTTChuck/MQTTChuckLog.swift
@@ -23,4 +23,15 @@ public struct MQTTChuckLog: Identifiable {
     public let dataString: String?
     
     public let timestamp = Date()
+    
+    public var isConnectOptionsAvailable: Bool { host != nil && !host!.isEmpty}
+    
+    public var host: String?
+    public var port: Int?
+    public var keepAlive: Int?
+    public var clientId: String?
+    public var isCleanSession: Bool?
+    public var userProperties: [String: String]?
+    public var alpn: [String]?
+    public var scheme: String?
 }

--- a/CourierMQTTChuck/MQTTChuckLogger.swift
+++ b/CourierMQTTChuck/MQTTChuckLogger.swift
@@ -55,7 +55,7 @@ public class MQTTChuckLogger {
             }
         }
         
-        let log = MQTTChuckLog(
+        var log = MQTTChuckLog(
             commandType: type.debugDescription,
             qos: "\(qos)",
             messageId: Int(mid),
@@ -63,6 +63,17 @@ public class MQTTChuckLogger {
             dup: dup, retained: retained,
             dataLength: data?.count,
             dataString: dataString)
+        
+        if let connectOptions = userInfo["connectOptions"] as? [String: Any] {
+            log.host = connectOptions["host"] as? String
+            log.port = connectOptions["port"] as? Int
+            log.keepAlive = connectOptions["keepAlive"] as? Int
+            log.clientId = connectOptions["clientId"] as? String
+            log.isCleanSession = connectOptions["isCleanSession"] as? Bool
+            log.userProperties = connectOptions["userProperties"] as? [String: String]
+            log.alpn = connectOptions["alpn"] as? [String]
+            log.scheme = connectOptions["scheme"] as? String
+        }
         
         logs.append(log)
         if logs.count >= logsMaxSize {

--- a/CourierMQTTChuck/MQTTChuckView.swift
+++ b/CourierMQTTChuck/MQTTChuckView.swift
@@ -172,12 +172,11 @@ struct MQTTChuckLogView: View {
             
             Section {
                 DisclosureGroup("Payload", isExpanded: $isPayloadExpanded) {
-                    Text("Message ID: \(log.messageId)")
-                    
-                    Text("Dup: \(String(log.dup)) - retained: \(String(log.retained))")
-                    
+                    TitleDetailHView(title: "MessageID", detail: String(log.messageId))
+                    TitleDetailHView(title: "Dup", detail: String(log.dup))
+                    TitleDetailHView(title: "Retained", detail: String(log.retained))
                     if let dataString = log.dataString {
-                        Text("data: \(dataString.debugDescription)")
+                        TitleDetailHView(title: "Bytes", detail: dataString.debugDescription)
                     } else {
                         Text("data: N/A")
                     }

--- a/CourierMQTTChuck/MQTTChuckView.swift
+++ b/CourierMQTTChuck/MQTTChuckView.swift
@@ -80,7 +80,6 @@ public struct MQTTChuckView: View {
             .containerShape(Rectangle())
             .contentShape(Rectangle())
             .onTapGesture { selectedLog = log }
-            
         }
     }
 }
@@ -148,7 +147,7 @@ struct MQTTChuckLogView: View {
                         if let clientId = log.clientId { TitleDetailHView(title: "ClientID", detail: clientId) }
                         if let keepAlive = log.keepAlive { TitleDetailHView(title: "Keep Alive", detail: String(keepAlive)) }
                         if let isCleanSession = log.isCleanSession { TitleDetailHView(title: "Clean Session", detail: String(isCleanSession)) }
-                                                                 
+                        
                         if let alpn = log.alpn {
                             VStack(alignment: .leading) {
                                 Text("ALPN")
@@ -156,7 +155,6 @@ struct MQTTChuckLogView: View {
                                     Text($0)
                                 }
                             }
-                           
                         }
                         
                         if let userProperties = log.userProperties {
@@ -167,13 +165,11 @@ struct MQTTChuckLogView: View {
                                 }
                             }
                         }
-                                                                  
+                        
                     }
                 }
-                
             }
             
-       
             Section {
                 DisclosureGroup("Payload", isExpanded: $isPayloadExpanded) {
                     Text("Message ID: \(log.messageId)")
@@ -191,7 +187,6 @@ struct MQTTChuckLogView: View {
         .textSelection(.enabled)
         .navigationTitle("Log Detail")
     }
-    
 }
 
 @available(iOS 15.0, *)
@@ -209,7 +204,6 @@ struct TitleDetailHView: View {
                 .multilineTextAlignment(.trailing)
         }
     }
-    
 }
 
 @available(iOS 15.0, *)
@@ -218,54 +212,3 @@ struct MQTTChuckView_Previews: PreviewProvider {
         MQTTChuckView(logger: MQTTChuckLogger())
     }
 }
-
-
-/*
- 
- HStack(alignment: .top) {
-     if log.sending {
-         Image(systemName: "arrow.up.message.fill")
-             .imageScale(.large)
-             .symbolRenderingMode(.multicolor)
-             .foregroundColor(.accentColor)
-     } else {
-         Image(systemName: "arrow.down.message.fill")
-             .imageScale(.large)
-             .symbolRenderingMode(.multicolor)
-             .foregroundColor(Color(uiColor: .systemGreen))
-     }
-     
-     VStack(alignment: .leading) {
-         HStack {
-             Text(log.commandType.uppercased())
-             Spacer()
-             Text("QOS: \(log.qos)")
-         }
-         .font(.headline)
-         
-         HStack(alignment: .top) {
-             Text(vm.dateFormatter.string(from: log.timestamp))
-             Spacer()
-
-             if let dataLength = log.dataLength {
-                 Text("\(dataLength) B")
-             } else {
-                 Text("-")
-             }
-         }
-         
-         DisclosureGroup("Details") {
-             Text("Message ID: \(log.messageId)")
-             
-             Text("Dup: \(String(log.dup)) - retained: \(String(log.retained))")
-             
-             if let dataString = log.dataString {
-                 Text("data: \(dataString.debugDescription)")
-             } else {
-                 Text("data: N/A")
-             }
-         }
-         .font(.caption)
-     }
- }
- */

--- a/CourierMQTTChuck/MQTTChuckView.swift
+++ b/CourierMQTTChuck/MQTTChuckView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 public struct MQTTChuckView: View {
     
     @StateObject var vm: MQTTChuckViewModel
+    @State var selectedLog: MQTTChuckLog?
     
     public init(logger: MQTTChuckLogger) {
         _vm = .init(wrappedValue: MQTTChuckViewModel(logger: logger))
@@ -27,6 +28,35 @@ public struct MQTTChuckView: View {
             }
         }
         .searchable(text: $vm.searchText)
+        .sheet(item: $selectedLog) { log in
+            if #available(iOS 16.0, *) {
+                NavigationStack {
+                    MQTTChuckLogView(log: log, dateFormatter: vm.dateFormatter)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarTrailing) {
+                                Button {
+                                    selectedLog = nil
+                                } label: {
+                                    Image(systemName: "xmark")
+                                }
+                            }
+                        }
+                }
+            } else {
+                NavigationView {
+                    MQTTChuckLogView(log: log, dateFormatter: vm.dateFormatter)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarTrailing) {
+                                Button {
+                                    selectedLog = nil
+                                } label: {
+                                    Image(systemName: "xclose")
+                                }
+                            }
+                        }
+                }
+            }
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
@@ -41,55 +71,145 @@ public struct MQTTChuckView: View {
     
     func forEachLogsView(logs: [MQTTChuckLog]) -> some View {
         ForEach(logs) { log in
-            HStack(alignment: .top) {
-                if log.sending {
-                    Image(systemName: "arrow.up.message.fill")
-                        .imageScale(.large)
-                        .symbolRenderingMode(.multicolor)
-                        .foregroundColor(.accentColor)
-                } else {
-                    Image(systemName: "arrow.down.message.fill")
-                        .imageScale(.large)
-                        .symbolRenderingMode(.multicolor)
-                        .foregroundColor(Color(uiColor: .systemGreen))
-                }
-                
-                VStack(alignment: .leading) {
-                    HStack {
-                        Text(log.commandType.uppercased())
-                        Spacer()
-                        Text("QOS: \(log.qos)")
-                    }
-                    .font(.headline)
-                    
-                    HStack(alignment: .top) {
-                        Text(vm.dateFormatter.string(from: log.timestamp))
-                        Spacer()
-
-                        if let dataLength = log.dataLength {
-                            Text("\(dataLength) B")
-                        } else {
-                            Text("-")
-                        }
-                    }
-                    
-                    DisclosureGroup("Details") {
-                        Text("Message ID: \(log.messageId)")
-                        
-                        Text("Dup: \(String(log.dup)) - retained: \(String(log.retained))")
-                        
-                        if let dataString = log.dataString {
-                            Text("data: \(dataString.debugDescription)")
-                        } else {
-                            Text("data: N/A")
-                        }
-                    }
-                    .font(.caption)
-                }
+            HStack {
+                MQTTChuckLogHeaderView(log: log, dateFormatter: vm.dateFormatter)
+                Image(systemName: "chevron.right")
+                    .symbolRenderingMode(.monochrome)
+                    .foregroundColor(.accentColor)
             }
-            .textSelection(.enabled)
+            .containerShape(Rectangle())
+            .contentShape(Rectangle())
+            .onTapGesture { selectedLog = log }
+            
         }
     }
+}
+
+@available(iOS 15.0, *)
+struct MQTTChuckLogHeaderView: View {
+    
+    let log: MQTTChuckLog
+    let dateFormatter: DateFormatter
+    
+    var body: some View {
+        HStack(alignment: .top) {
+            if log.sending {
+                Image(systemName: "arrow.up.message.fill")
+                    .imageScale(.large)
+                    .symbolRenderingMode(.multicolor)
+                    .foregroundColor(.accentColor)
+            } else {
+                Image(systemName: "arrow.down.message.fill")
+                    .imageScale(.large)
+                    .symbolRenderingMode(.multicolor)
+                    .foregroundColor(Color(uiColor: .systemGreen))
+            }
+            
+            VStack(alignment: .leading) {
+                HStack {
+                    Text(log.commandType.uppercased())
+                    Spacer()
+                    Text("QOS: \(log.qos)")
+                }
+                .font(.headline)
+                
+                HStack(alignment: .top) {
+                    Text(dateFormatter.string(from: log.timestamp))
+                    Spacer()
+                    if let dataLength = log.dataLength {
+                        Text("\(dataLength) B")
+                    } else {
+                        Text("-")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+struct MQTTChuckLogView: View {
+    
+    let log: MQTTChuckLog
+    let dateFormatter: DateFormatter
+    @State var isConnectionInfoExpanded = true
+    @State var isPayloadExpanded = true
+    
+    var body: some View {
+        List {
+            Section { MQTTChuckLogHeaderView(log: log, dateFormatter: dateFormatter) }
+            
+            if log.isConnectOptionsAvailable {
+                Section {
+                    DisclosureGroup("Connection Info", isExpanded: $isConnectionInfoExpanded) {
+                        if let host = log.host { TitleDetailHView(title: "Host", detail: host) }
+                        if let port = log.port { TitleDetailHView(title: "Port", detail: String(port)) }
+                        if let scheme = log.scheme { TitleDetailHView(title: "Scheme", detail: scheme) }
+                        if let clientId = log.clientId { TitleDetailHView(title: "ClientID", detail: clientId) }
+                        if let keepAlive = log.keepAlive { TitleDetailHView(title: "Keep Alive", detail: String(keepAlive)) }
+                        if let isCleanSession = log.isCleanSession { TitleDetailHView(title: "Clean Session", detail: String(isCleanSession)) }
+                                                                 
+                        if let alpn = log.alpn {
+                            VStack(alignment: .leading) {
+                                Text("ALPN")
+                                ForEach(alpn, id: \.self) {
+                                    Text($0)
+                                }
+                            }
+                           
+                        }
+                        
+                        if let userProperties = log.userProperties {
+                            VStack {
+                                Text("User Properties")
+                                ForEach(userProperties.map({ ($0, $1)}), id: \.0) {
+                                    TitleDetailHView(title: $0.0, detail: $0.1)
+                                }
+                            }
+                        }
+                                                                  
+                    }
+                }
+                
+            }
+            
+       
+            Section {
+                DisclosureGroup("Payload", isExpanded: $isPayloadExpanded) {
+                    Text("Message ID: \(log.messageId)")
+                    
+                    Text("Dup: \(String(log.dup)) - retained: \(String(log.retained))")
+                    
+                    if let dataString = log.dataString {
+                        Text("data: \(dataString.debugDescription)")
+                    } else {
+                        Text("data: N/A")
+                    }
+                }
+            }
+        }
+        .textSelection(.enabled)
+        .navigationTitle("Log Detail")
+    }
+    
+}
+
+@available(iOS 15.0, *)
+struct TitleDetailHView: View {
+    
+    let title: String
+    let detail: String
+    
+    var body: some View {
+        HStack(alignment: .top) {
+            Text(title)
+                .multilineTextAlignment(.leading)
+            Spacer()
+            Text(detail)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+    
 }
 
 @available(iOS 15.0, *)
@@ -98,3 +218,54 @@ struct MQTTChuckView_Previews: PreviewProvider {
         MQTTChuckView(logger: MQTTChuckLogger())
     }
 }
+
+
+/*
+ 
+ HStack(alignment: .top) {
+     if log.sending {
+         Image(systemName: "arrow.up.message.fill")
+             .imageScale(.large)
+             .symbolRenderingMode(.multicolor)
+             .foregroundColor(.accentColor)
+     } else {
+         Image(systemName: "arrow.down.message.fill")
+             .imageScale(.large)
+             .symbolRenderingMode(.multicolor)
+             .foregroundColor(Color(uiColor: .systemGreen))
+     }
+     
+     VStack(alignment: .leading) {
+         HStack {
+             Text(log.commandType.uppercased())
+             Spacer()
+             Text("QOS: \(log.qos)")
+         }
+         .font(.headline)
+         
+         HStack(alignment: .top) {
+             Text(vm.dateFormatter.string(from: log.timestamp))
+             Spacer()
+
+             if let dataLength = log.dataLength {
+                 Text("\(dataLength) B")
+             } else {
+                 Text("-")
+             }
+         }
+         
+         DisclosureGroup("Details") {
+             Text("Message ID: \(log.messageId)")
+             
+             Text("Dup: \(String(log.dup)) - retained: \(String(log.retained))")
+             
+             if let dataString = log.dataString {
+                 Text("data: \(dataString.debugDescription)")
+             } else {
+                 Text("data: N/A")
+             }
+         }
+         .font(.caption)
+     }
+ }
+ */

--- a/Podfile
+++ b/Podfile
@@ -19,7 +19,6 @@ end
 target 'CourierE2EApp' do
   use_frameworks!
   courier_pods
-  pod 'CourierMQTTChuck'
   pod 'SwiftProtobuf'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,19 +1,8 @@
 PODS:
-  - CourierCore (0.0.17)
-  - CourierMQTT (0.0.17):
-    - CourierCore (= 0.0.17)
-    - MQTTClientGJ (= 0.0.17)
-    - ReachabilitySwift (= 5.0.0)
-  - CourierMQTTChuck (0.0.17):
-    - CourierCore (= 0.0.17)
-    - CourierMQTT (= 0.0.17)
-    - MQTTClientGJ (= 0.0.17)
-  - MQTTClientGJ (0.0.17)
   - ReachabilitySwift (5.0.0)
   - SwiftProtobuf (1.17.0)
 
 DEPENDENCIES:
-  - CourierMQTTChuck
   - ReachabilitySwift (= 5.0.0)
   - SwiftProtobuf
 
@@ -21,20 +10,11 @@ SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - ReachabilitySwift
     - SwiftProtobuf
-  trunk:
-    - CourierCore
-    - CourierMQTT
-    - CourierMQTTChuck
-    - MQTTClientGJ
 
 SPEC CHECKSUMS:
-  CourierCore: 5561c7ff8fdd9b722bedf06a290be2f7e9242f80
-  CourierMQTT: 40ca2bde67a0a5c9c222c3e972861b34611907b8
-  CourierMQTTChuck: 970cd9893626cea84b0ebbd2db55533d356c7258
-  MQTTClientGJ: 2da01c1669f12cab46e2ddb0eb26e8b4cf54fe9c
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SwiftProtobuf: 9c85136c6ba74b0a1b84279dbf0f6db8efb714e0
 
-PODFILE CHECKSUM: 16cfd27c7166c9df2c4b15d142da9e4f5dd066d9
+PODFILE CHECKSUM: a4337e4674909ba3194470b783f5e8fa68363376
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
This MR contains following changes:
1. Revamps the UI of MQTTChuckView List by showing log in sheet presentation when user taps on a log.
2. Add Connection Info section containing data such as host, port, clientID, cleanSession, user properties, etc.

![Simulator Screen Shot - iPhone 14 Pro - 2023-07-24 at 10 34 22](https://github.com/gojek/courier-iOS/assets/6789991/858b2876-d4c5-4f0f-8a20-2d9139e31832)

![Simulator Screen Shot - iPhone 14 Pro - 2023-07-24 at 10 34 29](https://github.com/gojek/courier-iOS/assets/6789991/11a3ea2f-8e20-43c1-b6ff-06f9a2d81ccf)
