### PR TITLE
Only emit connection disconnect event for non-internal disconnect

### DIFF
--- a/CourierMQTT/MQTT/Client/IMQTTClient.swift
+++ b/CourierMQTT/MQTT/Client/IMQTTClient.swift
@@ -12,7 +12,7 @@ protocol IMQTTClient {
 
     func connect(connectOptions: ConnectOptions)
     func reconnect()
-    func disconnect()
+    func disconnect(isInternal: Bool)
 
     func subscribe(_ topics: [(topic: String, qos: QoS)])
     func unsubscribe(_ topics: [String])

--- a/CourierMQTT/MQTT/Client/MQTTClient.swift
+++ b/CourierMQTT/MQTT/Client/MQTTClient.swift
@@ -75,12 +75,14 @@ class MQTTClient: IMQTTClient {
             return
         }
         eventHandler.onEvent(.init(connectionInfo: options, event: .reconnect))
-        disconnect()
+        disconnect(isInternal: true)
         connect(connectOptions: options)
     }
 
-    func disconnect() {
-        eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .connectionDisconnect))
+    func disconnect(isInternal: Bool) {
+        if !isInternal {
+            eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .connectionDisconnect))
+        }
         isInitialized = false
         disconnectMqtt()
     }
@@ -185,7 +187,7 @@ class MQTTClient: IMQTTClient {
     }
 
     func destroy() {
-        disconnect()
+        disconnect(isInternal: false)
         connectOptions = nil
         removeObserveAppLifecycle()
         removeObserveNetwork()
@@ -218,7 +220,7 @@ extension MQTTClient {
 
 extension MQTTClient: KeepAliveFailureHandler {
     func handleKeepAliveFailure() {
-        disconnect()
+        disconnect(isInternal: true)
         reconnect()
     }
 }

--- a/CourierMQTT/MQTT/MQTTCourierClient.swift
+++ b/CourierMQTT/MQTT/MQTTCourierClient.swift
@@ -299,7 +299,7 @@ class MQTTCourierClient: CourierClient {
 
 extension MQTTCourierClient: IAuthFailureHandler {
     func handleAuthFailure() {
-        client.disconnect()
+        client.disconnect(isInternal: true)
         connectionServiceProvider.clearCachedAuthResponse()
         connect()
     }

--- a/CourierTests/Core/MQTT/Client/MQTTClientTests.swift
+++ b/CourierTests/Core/MQTT/Client/MQTTClientTests.swift
@@ -68,6 +68,7 @@ class MQTTClientTests: XCTestCase {
         } else {
             XCTAssert(false)
         }
+        XCTAssertEqual(self.mockEventHandler.invokedOnEventParametersList.count, 1)
         XCTAssertTrue(mockConnection.invokedConnect)
     }
 
@@ -114,10 +115,19 @@ class MQTTClientTests: XCTestCase {
         XCTAssertTrue(mockConnection.invokedUnsubscribe)
         XCTAssertEqual(mockConnection.invokedUnsubscribeParameters?.topics.first, "fbon")
     }
-
-    func testDisconnect() {
+    
+    func testDisconnectIsInternalTrue() {
         mockConnection.stubbedIsConnected = true
-        sut.disconnect()
+        sut.disconnect(isInternal: true)
+        
+        XCTAssertTrue(self.mockEventHandler.invokedOnEventParametersList.isEmpty)
+        XCTAssertFalse(sut.isInitialized)
+        XCTAssertTrue(mockConnection.invokedDisconnect)
+    }
+
+    func testDisconnectIsNotInternalFalse() {
+        mockConnection.stubbedIsConnected = true
+        sut.disconnect(isInternal: false)
 
         if case .connectionDisconnect = self.mockEventHandler.invokedOnEventParametersList.first!!.event.type {
             XCTAssert(true)
@@ -145,6 +155,12 @@ class MQTTClientTests: XCTestCase {
 
         XCTAssertFalse(sut.isInitialized)
         XCTAssertTrue(mockConnection.invokedDisconnect)
+        
+        if case .connectionDisconnect = self.mockEventHandler.invokedOnEventParametersList.first!!.event.type {
+            XCTAssert(true)
+        } else {
+            XCTAssert(false)
+        }
 
         XCTAssertNil(sut.connectOptions)
         XCTAssertEqual(mockNotificationCenter.invokedRemoveObserverWithNameParametersList[0].name, UIApplication.willResignActiveNotification)
@@ -168,6 +184,12 @@ class MQTTClientTests: XCTestCase {
 
         XCTAssertFalse(sut.isInitialized)
         XCTAssertTrue(mockConnection.invokedDisconnect)
+        
+        if case .connectionDisconnect = self.mockEventHandler.invokedOnEventParametersList.first!!.event.type {
+            XCTAssert(true)
+        } else {
+            XCTAssert(false)
+        }
 
         XCTAssertNil(sut.connectOptions)
         XCTAssertEqual(mockNotificationCenter.invokedRemoveObserverWithNameParametersList[0].name, UIApplication.didEnterBackgroundNotification)
@@ -186,6 +208,7 @@ class MQTTClientTests: XCTestCase {
         sut.handleKeepAliveFailure()
         XCTAssertTrue(mockConnection.invokedDisconnect)
         XCTAssertTrue(mockConnection.invokedConnect)
+        XCTAssertEqual(self.mockEventHandler.invokedOnEventParametersList.count, 1)
     }
 
     func testResetWithActiveNotifications() {

--- a/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
+++ b/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
@@ -221,7 +221,7 @@ class MQTTCourierClientTests: XCTestCase {
 
     func testHandleAuthFailure() {
         sut.handleAuthFailure()
-//        XCTAssertTrue(mockEventHandler.invokedReset)
+        XCTAssertTrue(mockClient.invokedDisconnectParameters!.isInternal)
         if case .connectionServiceAuthStart = self.mockEventHandler.invokedOnEventParameters?.event.type {
             XCTAssert(true)
         } else {

--- a/CourierTests/Core/Mocks/MockMQTTClient.swift
+++ b/CourierTests/Core/Mocks/MockMQTTClient.swift
@@ -86,10 +86,14 @@ class MockMQTTClient: IMQTTClient {
 
     var invokedDisconnect = false
     var invokedDisconnectCount = 0
+    var invokedDisconnectParameters: (isInternal: Bool, Void)?
+    var invokedDisconnectParametersList = [(isInternal: Bool, Void)]()
 
-    func disconnect() {
+    func disconnect(isInternal: Bool) {
         invokedDisconnect = true
         invokedDisconnectCount += 1
+        invokedDisconnectParameters = (isInternal, ())
+        invokedDisconnectParametersList.append((isInternal, ()))
     }
 
     var invokedSubscribe = false


### PR DESCRIPTION
This MR contains following changes:
- Connection Disconnect event is only emitted in case MQTTClient destroyed is invoked by client or it is deallocated from memory.
- In case of internal Reconnect, Auth Failure Handling, Keep Alive Failure Handling, the event won't be emitted.
- The purpose is to help users differentiate events between explicit/implicit disconnect. For example when they want to create a polling service, they should be able reliably listen to connection disconnect to cancel polling as it is an explicit disconnect by Courier.