### PR TITLE
Distribute CourierMQTT Pods as static frameworks 

### DIFF
--- a/CourierMQTT.podspec
+++ b/CourierMQTT.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |c|
 		:tag => "#{c.version}"
 	}
     c.swift_version   = '5.3'
+    c.static_framework = true
     c.source_files = "CourierMQTT/**/*.swift"
 
     c.dependency 'CourierCore', "#{c.version}"

--- a/CourierMQTTChuck.podspec
+++ b/CourierMQTTChuck.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |c|
 		:tag => "#{c.version}"
 	}
     c.swift_version   = '5.3'
-
+    c.static_framework = true
     c.source_files = "CourierMQTTChuck/**/*.swift"
 
     c.dependency 'CourierCore', "#{c.version}"

--- a/CourierProtobuf.podspec
+++ b/CourierProtobuf.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |c|
 		:tag => "#{c.version}"
 	}
     c.swift_version   = '5.3'
-
+    c.static_framework = true
     c.source_files = "CourierProtobuf/**/*.swift"
 
     c.dependency 'CourierCore', "#{c.version}"


### PR DESCRIPTION
Distribute CourierMQTT Pods as static frameworks since they depend on MQTTClientGJ Static XCFramework hence these pods also needs to be distributed as static frameworks

Otherwise while publishing podspec it fails with this error - https://github.com/gojek/courier-iOS/actions/runs/6244143979/job/16950738280 

This change is based on the suggestion here - https://github.com/CocoaPods/CocoaPods/issues/7234#issuecomment-346136322 