### PR TITLE
🔄 Migrated Courier-Test Target to Swift 6

### DIFF
--- a/Courier.xcodeproj/project.pbxproj
+++ b/Courier.xcodeproj/project.pbxproj
@@ -2555,6 +2555,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2614,6 +2615,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -2651,7 +2653,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.courier.CourierTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2686,7 +2688,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.courier.CourierTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -3010,6 +3012,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -3046,7 +3049,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.courier.CourierTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Integration;
@@ -3111,6 +3114,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -3147,7 +3151,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.courier.CourierTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Alpha;
@@ -3212,6 +3216,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -3248,7 +3253,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.courier.CourierTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Production;
@@ -3281,7 +3286,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -3314,7 +3319,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Production;
@@ -3347,7 +3352,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Alpha;
@@ -3380,7 +3385,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Integration;
@@ -3413,7 +3418,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/CourierCore.podspec
+++ b/CourierCore.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |c|
 
     c.homepage        = 'https://github.com/gojek/courier-iOS'
     c.license         = 'MIT'
-    c.author          = { "Alfian Losari" => "alfian.losari@gojek.com" }
+    c.author          = "Gojek"
     c.platform        = :ios, '13.0'
 
     c.source          = {

--- a/CourierMQTT.podspec
+++ b/CourierMQTT.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |c|
   
     c.homepage        = 'https://github.com/gojek/courier-iOS'
     c.license         = 'MIT'
-    c.author          = { "Alfian Losari" => "alfian.losari@gojek.com" }
+    c.author          = "Gojek"
     c.platform        = :ios, '13.0'
   
     c.source          = {

--- a/CourierMQTTChuck.podspec
+++ b/CourierMQTTChuck.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |c|
   
     c.homepage        = 'https://github.com/gojek/courier-iOS'
     c.license         = 'MIT'
-    c.author          = { "Alfian Losari" => "alfian.losari@gojek.com" }
+    c.author          = "Gojek"
     c.platform        = :ios, '13.0'
   
     c.source          = {

--- a/CourierProtobuf.podspec
+++ b/CourierProtobuf.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |c|
   
     c.homepage        = 'https://github.com/gojek/courier-iOS'
     c.license         = 'MIT'
-    c.author          = { "Alfian Losari" => "alfian.losari@gojek.com" }
+    c.author          = "Gojek"
     c.platform        = :ios, '13.0'
   
     c.source          = {

--- a/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
+++ b/CourierTests/Core/MQTT/Connection/MQTTClientFrameworkConnectionTests.swift
@@ -229,7 +229,7 @@ class MQTTClientFrameworkConnectionTests: XCTestCase {
         let error = NSError(domain: "", code: 5, userInfo: [:])
         mockSessionManager.stubbedLastError = error
         sut.sessionManager(mockSessionManager, didChangeState: .error)
-        if case let .connectionFailure(timeTaken, error) = self.mockEventHandler.invokedOnEventParametersList[0]?.event.type {
+        if case let .connectionFailure(_, error) = self.mockEventHandler.invokedOnEventParametersList[0]?.event.type {
             XCTAssertEqual((error! as NSError).code, 5)
         } else {
             XCTAssert(false)
@@ -317,14 +317,13 @@ class MQTTClientFrameworkConnectionTests: XCTestCase {
     
     func testDeleteAllPersistedMessage() {
         sut.deleteAllPersistedMessages()
-    
+        
         let expectation_ = expectation(description: "test")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
             expectation_.fulfill()
         }
-        waitForExpectations(timeout: 0.1) { _ in
-            XCTAssertTrue(self.mockSessionManager.invokedDeleteAllPersistedMessages)
-        }
+        wait(for: [expectation_], timeout: 0.1)
+        XCTAssertTrue(self.mockSessionManager.invokedDeleteAllPersistedMessages)
     }
 }
 

--- a/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
+++ b/CourierTests/Core/MQTT/MQTTCourierClientTests.swift
@@ -91,47 +91,50 @@ class MQTTCourierClientTests: XCTestCase {
         XCTAssertFalse(mockConnectionServiceProvider.invokedGetConnectOptions)
     }
 
-    func testConnectWithSuccessCredentials() {
+    @MainActor
+    func testConnectWithSuccessCredentials() async throws {
         mockConnectionServiceProvider.stubbedGetConnectOptionsCompletionResult = (.success(stubConnectOptions), ())
         sut.connect()
         let expectation_ = expectation(description: "test")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
             expectation_.fulfill()
         }
-        waitForExpectations(timeout: 0.1) { _ in
-            if case .connectionServiceAuthSuccess = self.mockEventHandler.invokedOnEventParameters?.event.type {
-            } else {
-                XCTAssert(false)
-            }
-            XCTAssertTrue(self.mockAuthRetryPolicy.invokedResetParams)
-            XCTAssertTrue(self.mockClient.invokedReset)
-            XCTAssertTrue(self.mockClient.invokedConnect)
-            
-            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.host, self.stubConnectOptions.host)
-            
-            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.port, UInt16(self.stubConnectOptions.port))
-            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.keepAlive, UInt16(self.pingInterval))
-            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.clientId, self.stubConnectOptions.clientId)
-            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.username, self.stubConnectOptions.username)
-            XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.password, self.stubConnectOptions.password)
-            
+        
+        await fulfillment(of: [expectation_], timeout: 1.0)
+        
+        if case .connectionServiceAuthSuccess = self.mockEventHandler.invokedOnEventParameters?.event.type {
+        } else {
+            XCTAssert(false)
         }
+        XCTAssertTrue(self.mockAuthRetryPolicy.invokedResetParams)
+        XCTAssertTrue(self.mockClient.invokedReset)
+        XCTAssertTrue(self.mockClient.invokedConnect)
+        
+        XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.host, self.stubConnectOptions.host)
+        
+        XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.port, UInt16(self.stubConnectOptions.port))
+        XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.keepAlive, UInt16(self.pingInterval))
+        XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.clientId, self.stubConnectOptions.clientId)
+        XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.username, self.stubConnectOptions.username)
+        XCTAssertEqual(self.mockClient.invokedConnectParameters?.connectOptions.password, self.stubConnectOptions.password)
     }
         
         
      
-
-    func testConnectWithFailureCredentials() {
+    @MainActor
+    func testConnectWithFailureCredentials() async throws {
         mockConnectionServiceProvider.stubbedGetConnectOptionsCompletionResult = (.failure(stubbedError), ())
         mockAuthRetryPolicy.stubbedGetRetryTimeResult = 0.1
-
+        
         sut.connect()
         let expectation_ = expectation(description: "test")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
             expectation_.fulfill()
         }
-        waitForExpectations(timeout: 0.1) { _ in
-            if case .connectionServiceAuthFailure = self.mockEventHandler.invokedOnEventParametersList[1]?.event.type {
+        
+        await fulfillment(of: [expectation_], timeout: 1.0)
+
+        if case .connectionServiceAuthFailure = self.mockEventHandler.invokedOnEventParametersList[1]?.event.type {
             XCTAssert(true)
         } else {
             XCTAssert(false)
@@ -142,9 +145,8 @@ class MQTTCourierClientTests: XCTestCase {
         } else {
             XCTAssert(false)
         }
-            XCTAssertTrue(self.mockAuthRetryPolicy.invokedShouldRetry)
-        }
-      
+        XCTAssertTrue(self.mockAuthRetryPolicy.invokedShouldRetry)
+        
     }
 
     func testSubscribeTopics() {
@@ -230,70 +232,68 @@ class MQTTCourierClientTests: XCTestCase {
         XCTAssertTrue(mockConnectionServiceProvider.invokedGetConnectOptions)
     }
 
-    func testOnConnectAttempt() {
-        testPublishConnectionState {
-            sut.onEvent(.init(connectionInfo: nil, event: .connectionAttempt))
-        }
+    @MainActor func testOnConnectAttempt() {
+             testPublishConnectionState {
+                sut.onEvent(.init(connectionInfo: nil, event: .connectionAttempt))
+            }
     }
 
-    func testOnConnectionSuccess() {
-        testPublishConnectionState {
-            sut.onEvent(.init(connectionInfo: nil, event: .connectionSuccess(timeTaken: 1)))
-            XCTAssertTrue(mockClient.invokedSubscribe)
-        }
+    @MainActor func testOnConnectionSuccess()  {
+             testPublishConnectionState {
+                sut.onEvent(.init(connectionInfo: nil, event: .connectionSuccess(timeTaken: 1)))
+                XCTAssertTrue(mockClient.invokedSubscribe)
+            }
     }
 
-    func testOnConnectionFailure() {
-        testPublishConnectionState {
-            sut.onEvent(.init(connectionInfo: nil, event: .connectionFailure(timeTaken: 1, error: nil)))
-        }
+    @MainActor func testOnConnectionFailure() {
+            testPublishConnectionState {
+                sut.onEvent(.init(connectionInfo: nil, event: .connectionFailure(timeTaken: 1, error: nil)))
+            }
     }
 
-    func testOnConnectionLost() {
-        testPublishConnectionState {
-            sut.onEvent(.init(connectionInfo: nil, event: .connectionLost(timeTaken: 1, error: nil, diffLastInbound: nil, diffLastOutbound: nil)))
-        }
+    @MainActor func testOnConnectionLost() {
+            testPublishConnectionState {
+                sut.onEvent(.init(connectionInfo: nil, event: .connectionLost(timeTaken: 1, error: nil, diffLastInbound: nil, diffLastOutbound: nil)))
+            }
     }
 
-    func testOnConnectionDisconnect() {
-        testPublishConnectionState {
-            sut.onEvent(.init(connectionInfo: nil, event: .connectionDisconnect))
-        }
+    @MainActor func testOnConnectionDisconnect() {
+             testPublishConnectionState {
+                sut.onEvent(.init(connectionInfo: nil, event: .connectionDisconnect))
+            }
     }
 
-    func testOnAppForegroundConnect() {
+    @MainActor
+    func testOnAppForegroundConnect() async throws {
         sut.onEvent(.init(connectionInfo: nil, event: .appForeground))
         let expectation_ = expectation(description: "test")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
             expectation_.fulfill()
         }
-        waitForExpectations(timeout: 0.1) { _ in
-//            XCTAssertTrue(self.mockEventHandler.invokedReset)
-            if case .connectionServiceAuthStart = self.mockEventHandler.invokedOnEventParameters?.event.type {
-                XCTAssert(true)
-            } else {
-                XCTAssert(false)
-            }
-            XCTAssertTrue(self.mockConnectionServiceProvider.invokedGetConnectOptions)
+        await fulfillment(of: [expectation_], timeout: 1.0)
+        if case .connectionServiceAuthStart = self.mockEventHandler.invokedOnEventParameters?.event.type {
+            XCTAssert(true)
+        } else {
+            XCTAssert(false)
         }
+        XCTAssertTrue(self.mockConnectionServiceProvider.invokedGetConnectOptions)
     }
 
-    func testOnConnectionAvailableConnect() {
+    @MainActor
+    func testOnConnectionAvailableConnect() async throws {
         mockSubscriptionStore.stubbedSubscriptions = stubbedTopicsDict
         sut.onEvent(.init(connectionInfo: nil, event: .connectionAvailable))
         let expectation_ = expectation(description: "test")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
             expectation_.fulfill()
         }
-        waitForExpectations(timeout: 0.1) { _ in
-//            XCTAssertTrue(self.mockEventHandler.invokedReset)
+        await fulfillment(of: [expectation_], timeout: 1.0)
             if case .connectionServiceAuthStart = self.mockEventHandler.invokedOnEventParameters?.event.type {
                 XCTAssert(true)
             } else {
                 XCTAssert(false)
             }
             XCTAssertTrue(self.mockConnectionServiceProvider.invokedGetConnectOptions)
-        }
     }
 
     func testMessageReceiveStream() {
@@ -323,17 +323,19 @@ class MQTTCourierClientTests: XCTestCase {
 }
 
 extension MQTTCourierClientTests {
-    func testPublishConnectionState(invocation: () -> Void) {
+    
+    @MainActor
+    func testPublishConnectionState(invocation: () -> Void)  {
         mockClient.stubbedIsConnected = true
-        let exp = expectation(description: "connect")
+        let expectation = expectation(description: "connect")
         sut.connectionStatePublisher
             .sink { state in
                 XCTAssertEqual(state, .connected)
-                exp.fulfill()
+                expectation.fulfill()
             }.store(in: &cancellables)
 
         invocation()
-        waitForExpectations(timeout: 0.1, handler: nil)
+        wait(for: [expectation], timeout: 0.1)
     }
 
     var stubbedTopicsDict: [String: QoS] {

--- a/CourierTests/Core/MQTT/Message/MQTTMessageReceiveListenerTests.swift
+++ b/CourierTests/Core/MQTT/Message/MQTTMessageReceiveListenerTests.swift
@@ -17,7 +17,8 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
         sut = MqttMessageReceiverListener(publishSubject: publishSubject, publishSubjectDispatchQueue: dispatchQueue)
     }
     
-    func testOnMessageArrived() {
+    @MainActor
+    func testOnMessageArrived() async throws {
         let exp = expectation(description: "messageArrived")
         let data = "hello".data(using: .utf8)!
         
@@ -33,10 +34,11 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
             .disposed(by: disposeBag)
         
         sut.messageArrived(data: data, topic: "fbon", qos: .two)
-        waitForExpectations(timeout: 0.1, handler: nil)
+        await fulfillment(of: [exp], timeout: 0.1)
     }
     
-    func testAddPublisherDict() {
+    @MainActor
+    func testAddPublisherDict() async throws {
         let exp = expectation(description: "messageArrivedIncomingMessagePersistence")
         let data = "hello".data(using: .utf8)!
 
@@ -57,8 +59,7 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
             }
             .disposed(by: disposeBag)
         
-        waitForExpectations(timeout: 3, handler: nil)
-
+        await fulfillment(of: [exp], timeout: 3)
     }
     
     func testRemovePublisherDict() {
@@ -78,7 +79,8 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
         XCTAssertTrue(mockMessagePersistence.invokedDeleteAllMessages)
     }
     
-    func testOnMessageArrivedWithIncomingMessagePersistenceEnabled() {
+    @MainActor
+    func testOnMessageArrivedWithIncomingMessagePersistenceEnabled() async throws {
         let exp = expectation(description: "messageArrivedIncomingMessagePersistence")
         let exp2 = expectation(description: "messageArrivedIncomingMessagePersistence2")
 
@@ -108,7 +110,7 @@ class MQTTMessageReceiveListenerTests: XCTestCase {
         }
         
         sut.messageArrived(data: data, topic: "fbon", qos: .two)
-        waitForExpectations(timeout: 3, handler: nil)
+        await fulfillment(of: [exp, exp2], timeout: 3)
     }
     
 }

--- a/CourierTests/ProtobufMessageAdapter/notes.pb.swift
+++ b/CourierTests/ProtobufMessageAdapter/notes.pb.swift
@@ -1,10 +1,11 @@
 import Foundation
-import SwiftProtobuf
+@preconcurrency import SwiftProtobuf
 
 private struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
     struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
     typealias Version = _2
 }
+
 
 struct Empty {
 

--- a/MQTTClientGJ.podspec
+++ b/MQTTClientGJ.podspec
@@ -3,8 +3,8 @@ Pod::Spec.new do |mqttc|
 	mqttc.version      = "0.0.27"
 	mqttc.summary      = "iOS, macOS and tvOS native ObjectiveC MQTT Client Framework"
 	mqttc.homepage     = "https://github.com/gojek/courier-iOS"
-	mqttc.license      = "EPLv1"
-	mqttc.author       = { "Alfian Losari" => "alfian.losari@gojek.com" }
+	mqttc.license 	   = { :type => 'EPLv1', :file => 'LICENSE.MQTTClientGJ' }
+	mqttc.author       = "Gojek"
 	mqttc.source       = {
 		:git => "https://github.com/gojek/courier-iOS.git",
 		:tag => "#{mqttc.version}"


### PR DESCRIPTION
🔄 Migrated **Courier-Test** Target to Swift 6

**Change Log -**

- Updated the Courier-Test target to support Swift 6.
- Resolved strict concurrency warnings and errors.
- Applied @MainActor, @preconcurrency fixes where necessary.
- Ensured compatibility with Swift 6's stricter isolation rules.
- Updated async test patterns using XCTestExpectation and fulfillment.