### PR TITLE
Distribute pods as dynamic/static as per client apps

### DIFF
--- a/CourierMQTT.podspec
+++ b/CourierMQTT.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |c|
 		:tag => "#{c.version}"
 	}
     c.swift_version = ['6.0', '5.3']
-    c.static_framework = true
     c.source_files = "CourierMQTT/**/*.swift"
 
     c.dependency 'CourierCore', "#{c.version}"

--- a/CourierMQTTChuck.podspec
+++ b/CourierMQTTChuck.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |c|
 		:tag => "#{c.version}"
 	}
     c.swift_version = ['6.0', '5.3']
-    c.static_framework = true
     c.source_files = "CourierMQTTChuck/**/*.swift"
 
     c.dependency 'CourierCore', "#{c.version}"

--- a/CourierProtobuf.podspec
+++ b/CourierProtobuf.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |c|
 		:tag => "#{c.version}"
 	}
     c.swift_version = ['6.0', '5.3']
-    c.static_framework = true
     c.source_files = "CourierProtobuf/**/*.swift"
 
     c.dependency 'CourierCore', "#{c.version}"


### PR DESCRIPTION
Removing hardcode static framework checks from podspec file and letting client app decide it